### PR TITLE
Changes to properly support the configuration of multiple message sources

### DIFF
--- a/Obvs.AzureServiceBus.Tests/EndpointProviderFacts.cs
+++ b/Obvs.AzureServiceBus.Tests/EndpointProviderFacts.cs
@@ -1,0 +1,283 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.ServiceBus.Messaging;
+using Moq;
+using Obvs.AzureServiceBus.Configuration;
+using Obvs.AzureServiceBus.Infrastructure;
+using Obvs.MessageProperties;
+using Obvs.Serialization;
+using Obvs.Serialization.Json;
+using Obvs.Types;
+using Xunit;
+
+namespace Obvs.AzureServiceBus.Tests
+{
+    public class EndpointProviderFacts
+    {
+        private readonly Func<Assembly, bool> _testAssemblyFilter = a => typeof(EndpointProviderFacts).Assembly.Equals(a);
+        private readonly Func<Type, bool> _testMessageTypeFilter = t => typeof(TestMessage).IsAssignableFrom(t);
+
+        private readonly List<MessageTypeMessagingEntityMappingDetails> _messageTypePathMappings;
+
+
+        public EndpointProviderFacts()
+        {
+            _messageTypePathMappings = new List<MessageTypeMessagingEntityMappingDetails>
+            {
+                new MessageTypeMessagingEntityMappingDetails(typeof(TestCommand), "commands", MessagingEntityType.Queue),
+                new MessageTypeMessagingEntityMappingDetails(typeof(TestEvent), "events", MessagingEntityType.Topic)
+            };
+        }
+
+        public class ConstructorFacts : EndpointProviderFacts
+        {
+            [Fact]
+            public void CreatingWithNullMessagingFactoryThrows()
+            {
+                Action action = () =>
+                {
+                    new AzureServiceBusEndpointProvider<TestMessage, TestMessage, TestCommand, TestEvent, TestRequest, TestResponse>("TestEndpoint", null, Mock.Of<IMessageSerializer>(), Mock.Of<IMessageDeserializerFactory>(), _messageTypePathMappings, _testAssemblyFilter, _testMessageTypeFilter, new MessagePropertyProviderManager<TestMessage>());
+                };
+
+                action.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("messagingFactory");
+            }
+
+            [Fact]
+            public void CreatingWithNullMessageSerializerThrows()
+            {
+                Action action = () =>
+                {
+                    new AzureServiceBusEndpointProvider<TestMessage, TestMessage, TestCommand, TestEvent, TestRequest, TestResponse>("TestEndpoint", Mock.Of<IMessagingFactory>(), null, Mock.Of<IMessageDeserializerFactory>(), _messageTypePathMappings, _testAssemblyFilter, _testMessageTypeFilter, new MessagePropertyProviderManager<TestMessage>());
+                };
+
+                action.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("messageSerializer");
+            }
+
+            [Fact]
+            public void CreatingWithNullMessageDeserializerFactoryThrows()
+            {
+                Action action = () =>
+                {
+                    new AzureServiceBusEndpointProvider<TestMessage, TestMessage, TestCommand, TestEvent, TestRequest, TestResponse>("TestEndpoint", Mock.Of<IMessagingFactory>(), Mock.Of<IMessageSerializer>(), null, _messageTypePathMappings, _testAssemblyFilter, _testMessageTypeFilter, new MessagePropertyProviderManager<TestMessage>());
+                };
+
+                action.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("messageDeserializerFactory");
+            }
+
+            [Fact]
+            public void CreatingWithNullMessageTypePathMappingsThrows()
+            {
+                Action action = () =>
+                {
+                    new AzureServiceBusEndpointProvider<TestMessage, TestMessage, TestCommand, TestEvent, TestRequest, TestResponse>("TestEndpoint", Mock.Of<IMessagingFactory>(), Mock.Of<IMessageSerializer>(), Mock.Of<IMessageDeserializerFactory>(), null, _testAssemblyFilter, _testMessageTypeFilter, new MessagePropertyProviderManager<TestMessage>());
+                };
+
+                action.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("messageTypePathMappings");
+            }
+
+            [Fact]
+            public void CreatingWithEmptyMessageTypePathMappingsThrows()
+            {
+                Action action = () =>
+                {
+                    new AzureServiceBusEndpointProvider<TestMessage, TestMessage, TestCommand, TestEvent, TestRequest, TestResponse>("TestEndpoint", Mock.Of<IMessagingFactory>(), Mock.Of<IMessageSerializer>(), Mock.Of<IMessageDeserializerFactory>(), new List<MessageTypeMessagingEntityMappingDetails>(), _testAssemblyFilter, _testMessageTypeFilter, new MessagePropertyProviderManager<TestMessage>());
+                };
+
+                action.ShouldThrow<ArgumentException>().And.ParamName.Should().Be("messageTypePathMappings");
+            }
+
+            [Fact]
+            public void CreatingWithNullMessagePropertyProviderManagerThrows()
+            {
+                Action action = () =>
+                {
+                    new AzureServiceBusEndpointProvider<TestMessage, TestMessage, TestCommand, TestEvent, TestRequest, TestResponse>("TestEndpoint", Mock.Of<IMessagingFactory>(), Mock.Of<IMessageSerializer>(), Mock.Of<IMessageDeserializerFactory>(), _messageTypePathMappings, _testAssemblyFilter, _testMessageTypeFilter, null);
+                };
+
+                action.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("messagePropertyProviderManager");
+            }
+        }
+
+        public class CreateEndpointFacts : EndpointProviderFacts
+        {
+            private readonly Mock<IMessagingFactory> _mockMessagingFactory = new Mock<IMessagingFactory>();
+            private readonly Mock<IMessageSerializer> _mockMessageSerializer = new Mock<IMessageSerializer>();
+            private readonly Mock<IMessageDeserializerFactory> _mockMessageDeserializerFactory = new Mock<IMessageDeserializerFactory>();
+            private readonly MessagePropertyProviderManager<TestMessage> _messagePropertyProviderManager = new MessagePropertyProviderManager<TestMessage>();
+
+            public CreateEndpointFacts()
+            {
+            }
+
+            [Fact]
+            public void CreateEndpoint()
+            {
+                new AzureServiceBusEndpointProvider<TestMessage, TestMessage, TestCommand, TestEvent, TestRequest, TestResponse>(
+                    "TestEndpoint", _mockMessagingFactory.Object, _mockMessageSerializer.Object, _mockMessageDeserializerFactory.Object, _messageTypePathMappings, _testAssemblyFilter, _testMessageTypeFilter, _messagePropertyProviderManager)
+                    .CreateEndpoint();
+            }
+
+            [Fact]
+            public async Task CanPublishEndpointEvents()
+            {
+                _messageTypePathMappings.Add(new MessageTypeMessagingEntityMappingDetails(typeof(TestSpecificEvent1), "events/subscriptions/specific-events-1", MessagingEntityType.Subscription));
+
+                var mockMessageSender = new Mock<IMessageSender>();
+                mockMessageSender.Setup(mr => mr.SendAsync(It.IsNotNull<BrokeredMessage>()))
+                    .Returns(Task.FromResult(true));
+
+                _mockMessagingFactory.Setup(mf => mf.CreateMessageSender(It.IsNotNull<Type>(), It.IsNotNull<string>()))
+                    .Returns(mockMessageSender.Object);
+
+                var endpointProvider = new AzureServiceBusEndpointProvider<TestMessage, TestMessage, TestCommand, TestEvent, TestRequest, TestResponse>(
+                    "TestEndpoint", _mockMessagingFactory.Object, new JsonMessageSerializer(), new JsonMessageDeserializerFactory(), _messageTypePathMappings, _testAssemblyFilter, _testMessageTypeFilter, _messagePropertyProviderManager);
+
+                var testEvent = new TestSpecificEvent1
+                {
+                    TestId = 1234
+                };
+
+                await endpointProvider.CreateEndpoint().PublishAsync(testEvent);
+
+                _mockMessagingFactory.Verify(mf => mf.CreateMessageSender(It.Is<Type>(t => t == typeof(TestSpecificEvent1)), It.Is<string>(s => s == "events")), Times.Once());
+
+                mockMessageSender.Verify(mr => mr.SendAsync(It.IsAny<BrokeredMessage>()), Times.Once());
+            }
+        }
+
+        public class CreateEndpointClientFacts : EndpointProviderFacts
+        {
+            private readonly Mock<IMessagingFactory> _mockMessagingFactory = new Mock<IMessagingFactory>();
+            private readonly Mock<IMessageSerializer> _mockMessageSerializer = new Mock<IMessageSerializer>();
+            private readonly Mock<IMessageDeserializerFactory> _mockMessageDeserializerFactory = new Mock<IMessageDeserializerFactory>();
+            private readonly MessagePropertyProviderManager<TestMessage> _messagePropertyProviderManager = new MessagePropertyProviderManager<TestMessage>();
+
+            public CreateEndpointClientFacts()
+            {
+            }
+
+
+            [Fact]
+            public void CreateEndpointClient()
+            {
+                new AzureServiceBusEndpointProvider<TestMessage, TestMessage, TestCommand, TestEvent, TestRequest, TestResponse>(
+                    "TestEndpoint", _mockMessagingFactory.Object, _mockMessageSerializer.Object, _mockMessageDeserializerFactory.Object, _messageTypePathMappings, _testAssemblyFilter, _testMessageTypeFilter, _messagePropertyProviderManager)
+                    .CreateEndpointClient();
+            }
+
+            [Fact]
+            public async Task CanReceiveEndpointClientEvents()
+            {
+                var testSubscriptionPath = "events/subscriptions/specific-events-1";
+
+                _messageTypePathMappings.Add(new MessageTypeMessagingEntityMappingDetails(typeof(TestSpecificEvent1), testSubscriptionPath, MessagingEntityType.Subscription));
+
+                var publishedEventBrokeredMessageTaskCompletionSource = new TaskCompletionSource<BrokeredMessage>();
+
+                var mockMessageReceiver = new Mock<IMessageReceiver>();
+                mockMessageReceiver.Setup(mr => mr.ReceiveAsync())
+                    .Returns(() => publishedEventBrokeredMessageTaskCompletionSource.Task);
+
+                _mockMessagingFactory.Setup(mf => mf.CreateMessageReceiver(It.IsNotNull<Type>(), It.IsNotNull<string>(), It.IsAny<MessageReceiveMode>()))
+                    .Returns(mockMessageReceiver.Object);
+
+                var mockMessageSender = new Mock<IMessageSender>();
+                mockMessageSender.Setup(mr => mr.SendAsync(It.IsNotNull<BrokeredMessage>()))
+                    .Callback<BrokeredMessage>(bm => 
+                    {
+
+                        publishedEventBrokeredMessageTaskCompletionSource.SetResult(bm);
+                        publishedEventBrokeredMessageTaskCompletionSource = new TaskCompletionSource<BrokeredMessage>();
+                    })
+                    .Returns(Task.FromResult(true));                
+
+                _mockMessagingFactory.Setup(mf => mf.CreateMessageSender(It.IsNotNull<Type>(), It.IsNotNull<string>()))
+                    .Returns(mockMessageSender.Object);
+
+                var endpointProvider = new AzureServiceBusEndpointProvider<TestMessage, TestMessage, TestCommand, TestEvent, TestRequest, TestResponse>(
+                    "TestEndpoint", _mockMessagingFactory.Object, new JsonMessageSerializer(), new JsonMessageDeserializerFactory(), _messageTypePathMappings, _testAssemblyFilter, _testMessageTypeFilter, _messagePropertyProviderManager);
+
+                var endpointClient = endpointProvider.CreateEndpointClient();
+
+                var publishedEvents = endpointClient.Events.SubscribeOn(TaskPoolScheduler.Default).Publish();
+
+                using(publishedEvents.Connect())
+                {
+                    await endpointProvider.CreateEndpoint().PublishAsync(new TestSpecificEvent1
+                    {
+                        TestId = 1234
+                    });
+
+                    var testEvent = await publishedEvents.FirstOrDefaultAsync();
+
+                    testEvent.Should().NotBeNull();
+                    testEvent.TestId.Should().Be(1234);
+                }
+
+                _mockMessagingFactory.Verify(mf => mf.CreateMessageReceiver(It.Is<Type>(it => it == typeof(TestSpecificEvent1)), testSubscriptionPath, It.Is<MessageReceiveMode>(mrm => mrm == MessageReceiveMode.ReceiveAndDelete)), Times.Once());
+
+                // NOTE: two times because the first time will return the msg for the test and then it will call ReceiveAsync again and block
+                mockMessageReceiver.Verify(mr => mr.ReceiveAsync(), Times.Exactly(2));
+            }
+        }
+
+        public class TestMessage : IMessage
+        {
+            public int TestId
+            {
+                get;
+                set;
+            }
+        }
+
+        public class TestCommand : TestMessage, ICommand
+        {
+
+        }
+
+        public class TestEvent : TestMessage, IEvent
+        {
+
+        }
+
+        public class TestSpecificEvent1 : TestEvent
+        {
+
+        }
+
+        public class TestRequest : TestMessage, IRequest
+        {
+            public string RequesterId
+            {
+                get;
+                set;
+            }
+
+            public string RequestId
+            {
+                get;
+                set;
+            }
+        }
+
+        public class TestResponse : TestMessage, IResponse
+        {
+            public string RequesterId
+            {
+                get;
+                set;
+            }
+
+            public string RequestId
+            {
+                get;
+                set;
+            }
+        }
+    }
+}

--- a/Obvs.AzureServiceBus.Tests/Obvs.AzureServiceBus.Tests.csproj
+++ b/Obvs.AzureServiceBus.Tests/Obvs.AzureServiceBus.Tests.csproj
@@ -34,28 +34,36 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FluentAssertions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\packages\FluentAssertions.4.0.0\lib\net45\FluentAssertions.dll</HintPath>
+    <Reference Include="FluentAssertions, Version=4.2.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.4.2.1\lib\net45\FluentAssertions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="FluentAssertions.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\packages\FluentAssertions.4.0.0\lib\net45\FluentAssertions.Core.dll</HintPath>
+    <Reference Include="FluentAssertions.Core, Version=4.2.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.4.2.1\lib\net45\FluentAssertions.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.ServiceBus, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\WindowsAzure.ServiceBus.3.0.4\lib\net45-full\Microsoft.ServiceBus.dll</HintPath>
+      <HintPath>..\packages\WindowsAzure.ServiceBus.3.1.2\lib\net45-full\Microsoft.ServiceBus.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.3.1.0\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
-    </Reference>
-    <Reference Include="Moq, Version=4.2.1507.118, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <HintPath>..\packages\Moq.4.2.1507.0118\lib\net40\Moq.dll</HintPath>
+      <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.3.2.0\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Obvs, Version=2.1.0.28, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Obvs.2.1.0.28\lib\net45\Obvs.dll</HintPath>
+    <Reference Include="Moq, Version=4.2.1510.2205, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\packages\Moq.4.2.1510.2205\lib\net40\Moq.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Obvs, Version=2.2.0.42, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Obvs.2.2.0.42\lib\net45\Obvs.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Obvs.Serialization.Json, Version=2.0.0.16, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Obvs.Serialization.Json.2.0.0.16\lib\net45\Obvs.Serialization.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -100,6 +108,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="EndpointProviderFacts.cs" />
     <Compile Include="MessagingEntityVerifierFacts.cs" />
     <Compile Include="ConfigurationFacts.cs" />
     <Compile Include="MessagePublisherFacts.cs" />

--- a/Obvs.AzureServiceBus.Tests/app.config
+++ b/Obvs.AzureServiceBus.Tests/app.config
@@ -4,46 +4,38 @@
 		<extensions>
 			<!-- In this extension section we are introducing all known service bus extensions. User can remove the ones they don't need. -->
 			<behaviorExtensions>
-				<add name="connectionStatusBehavior"
-					type="Microsoft.ServiceBus.Configuration.ConnectionStatusElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
-				<add name="transportClientEndpointBehavior"
-					type="Microsoft.ServiceBus.Configuration.TransportClientEndpointBehaviorElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
-				<add name="serviceRegistrySettings"
-					type="Microsoft.ServiceBus.Configuration.ServiceRegistrySettingsElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
+				<add name="connectionStatusBehavior" type="Microsoft.ServiceBus.Configuration.ConnectionStatusElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+				<add name="transportClientEndpointBehavior" type="Microsoft.ServiceBus.Configuration.TransportClientEndpointBehaviorElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+				<add name="serviceRegistrySettings" type="Microsoft.ServiceBus.Configuration.ServiceRegistrySettingsElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
 			</behaviorExtensions>
 			<bindingElementExtensions>
-				<add name="netMessagingTransport"
-					type="Microsoft.ServiceBus.Messaging.Configuration.NetMessagingTransportExtensionElement, Microsoft.ServiceBus,  Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
-				<add name="tcpRelayTransport"
-					type="Microsoft.ServiceBus.Configuration.TcpRelayTransportElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
-				<add name="httpRelayTransport"
-					type="Microsoft.ServiceBus.Configuration.HttpRelayTransportElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
-				<add name="httpsRelayTransport"
-					type="Microsoft.ServiceBus.Configuration.HttpsRelayTransportElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
-				<add name="onewayRelayTransport"
-					type="Microsoft.ServiceBus.Configuration.RelayedOnewayTransportElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
+				<add name="netMessagingTransport" type="Microsoft.ServiceBus.Messaging.Configuration.NetMessagingTransportExtensionElement, Microsoft.ServiceBus,  Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+				<add name="tcpRelayTransport" type="Microsoft.ServiceBus.Configuration.TcpRelayTransportElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+				<add name="httpRelayTransport" type="Microsoft.ServiceBus.Configuration.HttpRelayTransportElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+				<add name="httpsRelayTransport" type="Microsoft.ServiceBus.Configuration.HttpsRelayTransportElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+				<add name="onewayRelayTransport" type="Microsoft.ServiceBus.Configuration.RelayedOnewayTransportElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
 			</bindingElementExtensions>
 			<bindingExtensions>
-				<add name="basicHttpRelayBinding"
-					type="Microsoft.ServiceBus.Configuration.BasicHttpRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
-				<add name="webHttpRelayBinding"
-					type="Microsoft.ServiceBus.Configuration.WebHttpRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
-				<add name="ws2007HttpRelayBinding"
-					type="Microsoft.ServiceBus.Configuration.WS2007HttpRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
-				<add name="netTcpRelayBinding"
-					type="Microsoft.ServiceBus.Configuration.NetTcpRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
-				<add name="netOnewayRelayBinding"
-					type="Microsoft.ServiceBus.Configuration.NetOnewayRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
-				<add name="netEventRelayBinding"
-					type="Microsoft.ServiceBus.Configuration.NetEventRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
-				<add name="netMessagingBinding"
-					type="Microsoft.ServiceBus.Messaging.Configuration.NetMessagingBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
+				<add name="basicHttpRelayBinding" type="Microsoft.ServiceBus.Configuration.BasicHttpRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+				<add name="webHttpRelayBinding" type="Microsoft.ServiceBus.Configuration.WebHttpRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+				<add name="ws2007HttpRelayBinding" type="Microsoft.ServiceBus.Configuration.WS2007HttpRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+				<add name="netTcpRelayBinding" type="Microsoft.ServiceBus.Configuration.NetTcpRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+				<add name="netOnewayRelayBinding" type="Microsoft.ServiceBus.Configuration.NetOnewayRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+				<add name="netEventRelayBinding" type="Microsoft.ServiceBus.Configuration.NetEventRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+				<add name="netMessagingBinding" type="Microsoft.ServiceBus.Messaging.Configuration.NetMessagingBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
 			</bindingExtensions>
 		</extensions>
 	</system.serviceModel>
 	<appSettings>
 		<!-- Service Bus specific app setings for messaging connections -->
-		<add key="Microsoft.ServiceBus.ConnectionString"
-			value="Endpoint=sb://[your namespace].servicebus.windows.net;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=[your secret]"/>
+		<add key="Microsoft.ServiceBus.ConnectionString" value="Endpoint=sb://[your namespace].servicebus.windows.net;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=[your secret]" />
 	</appSettings>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/Obvs.AzureServiceBus.Tests/packages.config
+++ b/Obvs.AzureServiceBus.Tests/packages.config
@@ -1,15 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FluentAssertions" version="4.0.0" targetFramework="net45" />
-  <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net45" />
-  <package id="Moq" version="4.2.1507.0118" targetFramework="net45" />
-  <package id="Obvs" version="2.1.0.28" targetFramework="net45" />
+  <package id="FluentAssertions" version="4.2.1" targetFramework="net45" />
+  <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.0" targetFramework="net45" />
+  <package id="Moq" version="4.2.1510.2205" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net45" />
+  <package id="Obvs" version="2.2.0.42" targetFramework="net45" />
+  <package id="Obvs.Serialization.Json" version="2.0.0.16" targetFramework="net45" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Linq" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Main" version="2.2.5" targetFramework="net45" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net45" />
-  <package id="WindowsAzure.ServiceBus" version="3.0.4" targetFramework="net45" />
+  <package id="WindowsAzure.ServiceBus" version="3.1.2" targetFramework="net45" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net45" />

--- a/Obvs.AzureServiceBus/Configuration/AzureServiceBusEndpointProvider.cs
+++ b/Obvs.AzureServiceBus/Configuration/AzureServiceBusEndpointProvider.cs
@@ -1,15 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Reflection;
-using System.Text;
-using Microsoft.ServiceBus;
-using Microsoft.ServiceBus.Messaging;
 using Obvs.AzureServiceBus.Infrastructure;
 using Obvs.Configuration;
 using Obvs.MessageProperties;
 using Obvs.Serialization;
-using Obvs.Types;
 
 namespace Obvs.AzureServiceBus.Configuration
 {
@@ -21,43 +18,95 @@ namespace Obvs.AzureServiceBus.Configuration
         where TResponse : class, TMessage
         where TServiceMessage : class
     {
-        private readonly IMessageSerializer _serializer;
-        private readonly IMessageDeserializerFactory _deserializerFactory;
+        private readonly IMessageSerializer _messageSerializer;
+        private readonly IMessageDeserializerFactory _messageDeserializerFactory;
         private readonly Func<Assembly, bool> _assemblyFilter;
         private readonly Func<Type, bool> _typeFilter;
+        private readonly List<MessageTypeMessagingEntityMappingDetails> _messageTypePathMappings;
         private readonly MessagingEntityFactory _messageClientEntityFactory;
         private readonly MessagePropertyProviderManager<TMessage> _messagePropertyProviderManager;
-        
-        public AzureServiceBusEndpointProvider(string serviceName, INamespaceManager namespaceManager, IMessagingFactory messagingFactory, IMessageSerializer serializer, IMessageDeserializerFactory deserializerFactory, List<MessageTypeMessagingEntityMappingDetails> messageTypePathMappings, Func<Assembly, bool> assemblyFilter, Func<Type, bool> typeFilter, MessagePropertyProviderManager<TMessage> messagePropertyProviderManager)
+
+        public AzureServiceBusEndpointProvider(string serviceName, IMessagingFactory messagingFactory, IMessageSerializer messageSerializer, IMessageDeserializerFactory messageDeserializerFactory, List<MessageTypeMessagingEntityMappingDetails> messageTypePathMappings, Func<Assembly, bool> assemblyFilter, Func<Type, bool> typeFilter, MessagePropertyProviderManager<TMessage> messagePropertyProviderManager)
             : base(serviceName)
         {
-            _serializer = serializer;
-            _deserializerFactory = deserializerFactory;
+            if(messagingFactory == null) throw new ArgumentNullException(nameof(messagingFactory));
+            if(messageSerializer == null) throw new ArgumentNullException(nameof(messageSerializer));
+            if(messageDeserializerFactory == null) throw new ArgumentNullException(nameof(messageDeserializerFactory));
+            if(messageTypePathMappings == null) throw new ArgumentNullException(nameof(messageTypePathMappings));
+            if(messageTypePathMappings.Count == 0) throw new ArgumentException("An empty set of path mappings was specified.", nameof(messageTypePathMappings));
+            if(messagePropertyProviderManager == null) throw new ArgumentNullException(nameof(messagePropertyProviderManager));
+
+            _messageSerializer = messageSerializer;
+            _messageDeserializerFactory = messageDeserializerFactory;
             _assemblyFilter = assemblyFilter;
             _typeFilter = typeFilter;
-            _messageClientEntityFactory = new MessagingEntityFactory(messagingFactory, messageTypePathMappings);
+            _messageTypePathMappings = messageTypePathMappings;
             _messagePropertyProviderManager = messagePropertyProviderManager;
+
+            _messageClientEntityFactory = new MessagingEntityFactory(messagingFactory, messageTypePathMappings);
         }
 
         public override IServiceEndpoint<TMessage, TCommand, TEvent, TRequest, TResponse> CreateEndpoint()
         {
             return new ServiceEndpoint<TMessage, TCommand, TEvent, TRequest, TResponse>(
-               new MessageSource<TRequest>(_messageClientEntityFactory, _deserializerFactory.Create<TRequest, TServiceMessage>(_assemblyFilter, _typeFilter)),
-               new MessageSource<TCommand>(_messageClientEntityFactory, _deserializerFactory.Create<TCommand, TServiceMessage>(_assemblyFilter, _typeFilter)),
-               new MessagePublisher<TEvent>(_messageClientEntityFactory, _serializer, _messagePropertyProviderManager.GetMessagePropertyProviderFor<TEvent>()),
-               new MessagePublisher<TResponse>(_messageClientEntityFactory, _serializer, _messagePropertyProviderManager.GetMessagePropertyProviderFor<TResponse>()),
+               GetMessageSource<TRequest>(),
+               GetMessageSource<TCommand>(),
+               new MessagePublisher<TEvent>(_messageClientEntityFactory, _messageSerializer, _messagePropertyProviderManager.GetMessagePropertyProviderFor<TEvent>()),
+               new MessagePublisher<TResponse>(_messageClientEntityFactory, _messageSerializer, _messagePropertyProviderManager.GetMessagePropertyProviderFor<TResponse>()),
                typeof(TServiceMessage));
         }
 
 
         public override IServiceEndpointClient<TMessage, TCommand, TEvent, TRequest, TResponse> CreateEndpointClient()
         {
+
             return new ServiceEndpointClient<TMessage, TCommand, TEvent, TRequest, TResponse>(
-               new MessageSource<TEvent>(_messageClientEntityFactory, _deserializerFactory.Create<TEvent, TServiceMessage>(_assemblyFilter, _typeFilter)),
-               new MessageSource<TResponse>(_messageClientEntityFactory, _deserializerFactory.Create<TResponse, TServiceMessage>(_assemblyFilter, _typeFilter)),
-               new MessagePublisher<TRequest>(_messageClientEntityFactory, _serializer, _messagePropertyProviderManager.GetMessagePropertyProviderFor<TRequest>()),
-               new MessagePublisher<TCommand>(_messageClientEntityFactory, _serializer, _messagePropertyProviderManager.GetMessagePropertyProviderFor<TCommand>()),
+               GetMessageSource<TEvent>(),
+               GetMessageSource<TResponse>(),
+               new MessagePublisher<TRequest>(_messageClientEntityFactory, _messageSerializer, _messagePropertyProviderManager.GetMessagePropertyProviderFor<TRequest>()),
+               new MessagePublisher<TCommand>(_messageClientEntityFactory, _messageSerializer, _messagePropertyProviderManager.GetMessagePropertyProviderFor<TCommand>()),
                typeof(TServiceMessage));
         }
-    }    
+
+        private IMessageSource<TSourceMessage> GetMessageSource<TSourceMessage>() where TSourceMessage : class, TMessage
+        {
+            // Find mappings for source types thare are assignable from the target type
+            var sourceMessageTypePathMappings = (from mtpm in _messageTypePathMappings
+                                                 where (mtpm.MessagingEntityType == MessagingEntityType.Queue
+                                                           ||
+                                                       mtpm.MessagingEntityType == MessagingEntityType.Subscription)
+                                                           &&
+                                                       typeof(TSourceMessage).IsAssignableFrom(mtpm.MessageType)
+                                                 select mtpm);
+
+            IMessageSource<TSourceMessage> result;
+
+            // If there's only one target path mapping for this message type then just return a single MessageSource<T> instance (avoid overhead of MergedMessageSource)
+            if(sourceMessageTypePathMappings.Count() == 1)
+            {
+                result = CreateMessageSource<TSourceMessage>(sourceMessageTypePathMappings.First().MessageType);
+            }
+            else
+            {
+                result = new MergedMessageSource<TSourceMessage>(sourceMessageTypePathMappings.Select(mtpm => CreateMessageSource<TSourceMessage>(mtpm.MessageType)));
+            }
+
+            return result;
+        }
+
+        private IMessageSource<TSourceMessage> CreateMessageSource<TSourceMessage>(Type messageType) where TSourceMessage : class, TMessage
+        {
+            Type messageSourceType = typeof(MessageSource<>).MakeGenericType(messageType);
+            Type messageSourceDeserializerType = typeof(IMessageDeserializer<>).MakeGenericType(messageType);
+
+            return Expression.Lambda<Func<IMessageSource<TSourceMessage>>>(
+                    Expression.New(messageSourceType.GetConstructor(new Type[] { typeof(IMessagingEntityFactory), typeof(IEnumerable<>).MakeGenericType(messageSourceDeserializerType) }),
+                Expression.Constant(_messageClientEntityFactory),
+                Expression.Call(
+                    Expression.Constant(_messageDeserializerFactory),
+                    typeof(IMessageDeserializerFactory).GetMethod("Create").MakeGenericMethod(messageType, typeof(TServiceMessage)),
+                    Expression.Constant(_assemblyFilter, typeof(Func<Assembly, bool>)),
+                    Expression.Constant(_typeFilter, typeof(Func<Type, bool>))))).Compile().Invoke();
+        }
+    }
 }

--- a/Obvs.AzureServiceBus/Configuration/AzureServiceBusFluentConfig.cs
+++ b/Obvs.AzureServiceBus/Configuration/AzureServiceBusFluentConfig.cs
@@ -139,7 +139,7 @@ namespace Obvs.AzureServiceBus.Configuration
 
             _messagingEntityVerifier.EnsureMessagingEntitiesExist(_messageTypePathMappings);
 
-            return new AzureServiceBusEndpointProvider<TServiceMessage, TMessage, TCommand, TEvent, TRequest, TResponse>(_serviceName, _namespaceManager, _messagingFactory, _serializer, _deserializerFactory, _messageTypePathMappings, _assemblyFilter, _typeFilter, _messagePropertyProviderManager);
+            return new AzureServiceBusEndpointProvider<TServiceMessage, TMessage, TCommand, TEvent, TRequest, TResponse>(_serviceName, _messagingFactory, _serializer, _deserializerFactory, _messageTypePathMappings, _assemblyFilter, _typeFilter, _messagePropertyProviderManager);
         }        
 
         public ICanSpecifyAzureServiceBusMessagingFactory<TMessage, TCommand, TEvent, TRequest, TResponse> WithConnectionString(string connectionString)

--- a/Obvs.AzureServiceBus/Obvs.AzureServiceBus.csproj
+++ b/Obvs.AzureServiceBus/Obvs.AzureServiceBus.csproj
@@ -31,15 +31,15 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.ServiceBus, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\WindowsAzure.ServiceBus.3.0.4\lib\net45-full\Microsoft.ServiceBus.dll</HintPath>
+      <HintPath>..\packages\WindowsAzure.ServiceBus.3.1.2\lib\net45-full\Microsoft.ServiceBus.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.3.1.0\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
+      <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.3.2.0\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Obvs, Version=2.1.0.28, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Obvs.2.1.0.28\lib\net45\Obvs.dll</HintPath>
+    <Reference Include="Obvs, Version=2.2.0.42, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Obvs.2.2.0.42\lib\net45\Obvs.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Obvs.AzureServiceBus/Properties/AssemblyInfo.cs
+++ b/Obvs.AzureServiceBus/Properties/AssemblyInfo.cs
@@ -14,8 +14,8 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-[assembly: AssemblyVersion("0.6.1.*")]
-[assembly: AssemblyInformationalVersion("0.6.1-beta")]
+[assembly: AssemblyVersion("0.6.2.*")]
+[assembly: AssemblyInformationalVersion("0.6.2-beta")]
 
 [assembly: InternalsVisibleTo("Obvs.AzureServiceBus.Tests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/Obvs.AzureServiceBus/packages.config
+++ b/Obvs.AzureServiceBus/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net45" />
-  <package id="Obvs" version="2.1.0.28" targetFramework="net45" />
+  <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.0" targetFramework="net45" />
+  <package id="Obvs" version="2.2.0.42" targetFramework="net45" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Linq" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Main" version="2.2.5" targetFramework="net45" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net45" />
-  <package id="WindowsAzure.ServiceBus" version="3.0.4" targetFramework="net45" />
+  <package id="WindowsAzure.ServiceBus" version="3.1.2" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
- Updated to latest versions of all dependent packages (were a little behind on things).
- Fixing bug in the observable stream that is returned from MessageSource::CreateBrokeredMessageObservableFromMessageReceiver where, if an exception occurred, we were reporting it to the observer via OnError, but we were not terminating processing and would send more data through the observer, but that violates Rx rules that say OnError must terminate the stream.
- Now disposing of received BrokeredMessages. If non-peek-lock they are disposed of immediately after parsing by the MessageSource classes Messages observerable implementation. If peek-lock, they are disposed after a completion action is performed by the PeekLockMessageControl class.
- Fixing bug in MessagePublisher where we were disposing of the MemoryStream that was being used for serialization. This is technically a bug because the BrokeredMessage assumes ownership of this stream and will dispose of it when _it_ is disposed.
- Stopped passing the namespace manager into AzureServiceBusEndpointProvider because it doesn't use it.
- Started updating to use C#6 nameof() for parameter validation logic so that we're not using fragile strings and get rename refactoring and compile time validation
- Started adding some EndpointProviderFacts
