### PR TITLE
Upgrading to Obvs 3.x.

### DIFF
--- a/Obvs.AzureServiceBus.Tests/EndpointProviderFacts.cs
+++ b/Obvs.AzureServiceBus.Tests/EndpointProviderFacts.cs
@@ -221,8 +221,11 @@ namespace Obvs.AzureServiceBus.Tests
 
                 _mockMessagingFactory.Verify(mf => mf.CreateMessageReceiver(It.Is<Type>(it => it == typeof(TestSpecificEvent1)), testSubscriptionPath, It.Is<MessageReceiveMode>(mrm => mrm == MessageReceiveMode.ReceiveAndDelete)), Times.Once());
 
-                // NOTE: two times because the first time will return the msg for the test and then it will call ReceiveAsync again and block
-                mockMessageReceiver.Verify(mr => mr.ReceiveAsync(), Times.Exactly(2));
+                /* NOTE: it's possible ReceiveAsync will be called up to two times due to concurrency here: 
+                 * the first time will return the msg for the test, but then it's possible there will be a second call to ReceiveAsync to wait for the next message 
+                 * before the subscription is shut down.
+                 */
+                mockMessageReceiver.Verify(mr => mr.ReceiveAsync(), Times.AtMost(2));
             }
         }
 

--- a/Obvs.AzureServiceBus.Tests/Obvs.AzureServiceBus.Tests.csproj
+++ b/Obvs.AzureServiceBus.Tests/Obvs.AzureServiceBus.Tests.csproj
@@ -58,8 +58,8 @@
       <HintPath>..\packages\Newtonsoft.Json.8.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Obvs, Version=2.2.0.42, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Obvs.2.2.0.42\lib\net45\Obvs.dll</HintPath>
+    <Reference Include="Obvs, Version=3.0.0.47, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Obvs.3.0.0.47\lib\net45\Obvs.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Obvs.Serialization.Json, Version=2.0.0.16, Culture=neutral, processorArchitecture=MSIL">

--- a/Obvs.AzureServiceBus.Tests/packages.config
+++ b/Obvs.AzureServiceBus.Tests/packages.config
@@ -4,7 +4,7 @@
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.0" targetFramework="net45" />
   <package id="Moq" version="4.2.1510.2205" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net45" />
-  <package id="Obvs" version="2.2.0.42" targetFramework="net45" />
+  <package id="Obvs" version="3.0.0.47" targetFramework="net45" />
   <package id="Obvs.Serialization.Json" version="2.0.0.16" targetFramework="net45" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net45" />

--- a/Obvs.AzureServiceBus/Obvs.AzureServiceBus.csproj
+++ b/Obvs.AzureServiceBus/Obvs.AzureServiceBus.csproj
@@ -38,8 +38,8 @@
       <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.3.2.0\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Obvs, Version=2.2.0.42, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Obvs.2.2.0.42\lib\net45\Obvs.dll</HintPath>
+    <Reference Include="Obvs, Version=3.0.0.47, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Obvs.3.0.0.47\lib\net45\Obvs.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Obvs.AzureServiceBus/Obvs.AzureServiceBus.nuspec
+++ b/Obvs.AzureServiceBus/Obvs.AzureServiceBus.nuspec
@@ -11,8 +11,7 @@
         <copyright>Copyright 2015</copyright>
         <tags>Azure Commands Events CQRS Rx Observable</tags>
         <releaseNotes>
-            * Support for non-IMessage message types for PeekLockMessageControlExtensions::GetPeekLockMessageControl
-            * Renamed IMessageClientEntityFactory -> IMessagingEntityFactory
+            * Upgrading to Obvs 3.x
         </releaseNotes>
     </metadata>
 </package>

--- a/Obvs.AzureServiceBus/Properties/AssemblyInfo.cs
+++ b/Obvs.AzureServiceBus/Properties/AssemblyInfo.cs
@@ -14,8 +14,8 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-[assembly: AssemblyVersion("0.6.2.*")]
-[assembly: AssemblyInformationalVersion("0.6.2-beta")]
+[assembly: AssemblyVersion("0.8.0.*")]
+[assembly: AssemblyInformationalVersion("0.8.0-beta")]
 
 [assembly: InternalsVisibleTo("Obvs.AzureServiceBus.Tests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/Obvs.AzureServiceBus/packages.config
+++ b/Obvs.AzureServiceBus/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.0" targetFramework="net45" />
-  <package id="Obvs" version="2.2.0.42" targetFramework="net45" />
+  <package id="Obvs" version="3.0.0.47" targetFramework="net45" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Linq" version="2.2.5" targetFramework="net45" />


### PR DESCRIPTION
- Upgraded to Obvs 3.x compatibility
- Fixed concurrency bug in test that lead to the test not always passing
