### PR TITLE
Added a simpler overload of the WithAzureServiceBusEndpoint

### DIFF
--- a/Obvs.AzureServiceBus.sln
+++ b/Obvs.AzureServiceBus.sln
@@ -1,11 +1,16 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.25008.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Obvs.AzureServiceBus", "Obvs.AzureServiceBus\Obvs.AzureServiceBus.csproj", "{2C889E39-B633-4EC8-9BF0-4C98DB630B0A}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Obvs.AzureServiceBus.Tests", "Obvs.AzureServiceBus.Tests\Obvs.AzureServiceBus.Tests.csproj", "{15275F11-AF1B-4787-8B6D-E52ABDB4C705}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{28AFCC67-5ECF-4224-9BB1-3F87D2CF8F8B}"
+	ProjectSection(SolutionItems) = preProject
+		README.md = README.md
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Obvs.AzureServiceBus/Configuration/AzureServiceBusConfigExtensions.cs
+++ b/Obvs.AzureServiceBus/Configuration/AzureServiceBusConfigExtensions.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Obvs.Configuration;
+﻿using Obvs.Configuration;
 using Obvs.Types;
 
 namespace Obvs.AzureServiceBus.Configuration
@@ -11,14 +6,24 @@ namespace Obvs.AzureServiceBus.Configuration
     public static class AzureServiceBusConfigExtensions
     {
         public static ICanAddAzureServiceBusServiceName<TMessage, TCommand, TEvent, TRequest, TResponse> WithAzureServiceBusEndpoint<TServiceMessage, TMessage, TCommand, TEvent, TRequest, TResponse>(this ICanAddEndpoint<TMessage, TCommand, TEvent, TRequest, TResponse> canAddEndpoint) 
-            where TMessage : class
             where TServiceMessage : class
+            where TMessage : class
             where TCommand : class, TMessage
             where TEvent : class, TMessage
             where TRequest : class, TMessage
             where TResponse : class, TMessage
         {
             return new AzureServiceBusFluentConfig<TServiceMessage, TMessage, TCommand, TEvent, TRequest, TResponse>(canAddEndpoint);
+        }
+
+        public static ICanAddAzureServiceBusServiceName<TMessage, TCommand, TEvent, TRequest, TResponse> WithAzureServiceBusEndpoint<TMessage, TCommand, TEvent, TRequest, TResponse>(this ICanAddEndpoint<TMessage, TCommand, TEvent, TRequest, TResponse> canAddEndpoint)
+            where TMessage : class
+            where TCommand : class, TMessage
+            where TEvent : class, TMessage
+            where TRequest : class, TMessage
+            where TResponse : class, TMessage
+        {
+            return canAddEndpoint.WithAzureServiceBusEndpoint<TMessage, TMessage, TCommand, TEvent, TRequest, TResponse>();
         }
 
         public static ICanAddAzureServiceBusServiceName<IMessage, ICommand, IEvent, IRequest, IResponse> WithAzureServiceBusEndpoint<TServiceMessage>(this ICanAddEndpoint<IMessage, ICommand, IEvent, IRequest, IResponse> canAddEndpoint) where TServiceMessage : class

--- a/Obvs.AzureServiceBus/Obvs.AzureServiceBus.nuspec
+++ b/Obvs.AzureServiceBus/Obvs.AzureServiceBus.nuspec
@@ -11,7 +11,7 @@
         <copyright>Copyright 2015</copyright>
         <tags>Azure Commands Events CQRS Rx Observable</tags>
         <releaseNotes>
-            * Upgrading to Obvs 3.x
+            * Added a simpler overload of the WithAzureServiceBusEndpoint configuration method that assumes TServiceMessage is same as TMessage which allows for simpler configuration
         </releaseNotes>
     </metadata>
 </package>

--- a/Obvs.AzureServiceBus/Properties/AssemblyInfo.cs
+++ b/Obvs.AzureServiceBus/Properties/AssemblyInfo.cs
@@ -14,8 +14,8 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-[assembly: AssemblyVersion("0.8.0.*")]
-[assembly: AssemblyInformationalVersion("0.8.0-beta")]
+[assembly: AssemblyVersion("0.9.0.*")]
+[assembly: AssemblyInformationalVersion("0.9.0-beta")]
 
 [assembly: InternalsVisibleTo("Obvs.AzureServiceBus.Tests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ full control you would expect over peek-lock style messages as if you were worki
 
 *Please note:* you must opt-in to `PeekLock` mode as the default is `ReceiveAndDelete`. This is to stay consistent with the Azure Service Bus API itself.
 
-[You can read more on this subject here in the Wiki.](https://github.com/drub0y/Obvs.AzureServiceBus/wiki/Peek-Lock-Message-Processing-Pattern-Support). 
+[You can read more on this subject here in the Wiki.](https://github.com/drub0y/Obvs.AzureServiceBus/wiki/Peek-Lock-Message-Processing-Pattern-Support)
 
 ---   
 
@@ -36,7 +36,7 @@ Shows how to configure the bus to send commands to an Azure Service Bus Queue.
 ```C#
 // Configure the bus with a queue
 var serviceBusClient = ServiceBus<MyMessage, MyCommand, MyEvent, MyRequest, MyResponse>.Configure()
-                .WithAzureServiceBusEndpoint<MyMessage, MyMessage, MyCommand, MyEvent, MyRequest, MyResponse>()
+                .WithAzureServiceBusEndpoint()
                 .Named("My Service Bus")
                 .WithConnectionString(ConfigurationManager.AppSettings["MyServiceBusConnectionString"])
                 .UsingQueueFor<MyCommand>("my-commands")
@@ -52,7 +52,7 @@ await serviceBusClient.SendAsync(new MyFancyCommand());
 ```C#
 // Configure the bus with a topic
 var serviceBus = ServiceBus<MyMessage, MyCommand, MyEvent, MyRequest, MyResponse>.Configure()
-                .WithAzureServiceBusEndpoint<MyMessage, MyMessage, MyCommand, MyEvent, MyRequest, MyResponse>()
+                .WithAzureServiceBusEndpoint()
                 .Named("My Service Bus")
                 .WithConnectionString(ConfigurationManager.AppSettings["MyServiceBusConnectionString"])
                 .UsingTopicFor<MyEvent>("my-events")
@@ -69,7 +69,7 @@ await serviceBus.PublishAsync(new MySpecialEvent());
 ```C#
 // Configure the bus with a specific subscription
 var serviceBusClient = ServiceBus<MyMessage, MyCommand, MyEvent, MyRequest, MyResponse>.Configure()
-                .WithAzureServiceBusEndpoint<MyMessage, MyMessage, MyCommand, MyEvent, MyRequest, MyResponse>()
+                .WithAzureServiceBusEndpoint()
                 .Named("My Service Bus")
                 .WithConnectionString(ConfigurationManager.AppSettings["MyServiceBusConnectionString"])
                 .UsingSubscriptionFor<MyEvent>("my-events", "my-subscription", MessageReceiveMode.PeekLock)


### PR DESCRIPTION
- Added simpler overloead of configuration method that assumes TServiceMessage is same as TMessage which allows for simpler configuration because all the types are inferred from the ICanAddEndpoint<>
- Updated configuration samples in README
- Bumped version and nuspec info
