### PR TITLE
Making ReceiveAndDelete the default MessageReceiveMode.

### DIFF
--- a/Obvs.AzureServiceBus/Configuration/AzureServiceBusFluentConfig.cs
+++ b/Obvs.AzureServiceBus/Configuration/AzureServiceBusFluentConfig.cs
@@ -13,8 +13,8 @@ namespace Obvs.AzureServiceBus.Configuration
 {
     public enum MessageReceiveMode
     {
-        PeekLock,
-        ReceiveAndDelete
+        ReceiveAndDelete = 0,
+        PeekLock = 1
     }
 
     public interface ICanAddAzureServiceBusServiceName<TMessage, TCommand, TEvent, TRequest, TResponse>
@@ -202,7 +202,7 @@ namespace Obvs.AzureServiceBus.Configuration
 
         public ICanSpecifyAzureServiceBusMessagingEntity<TMessage, TCommand, TEvent, TRequest, TResponse> UsingQueueFor<T>(string queuePath) where T : class, TMessage
         {
-            return UsingQueueFor<T>(queuePath, MessageReceiveMode.PeekLock);
+            return UsingQueueFor<T>(queuePath, MessageReceiveMode.ReceiveAndDelete);
         }
 
         public ICanSpecifyAzureServiceBusMessagingEntity<TMessage, TCommand, TEvent, TRequest, TResponse> UsingQueueFor<T>(string queuePath, MessageReceiveMode receiveMode) where T : class, TMessage
@@ -212,7 +212,7 @@ namespace Obvs.AzureServiceBus.Configuration
 
         public ICanSpecifyAzureServiceBusMessagingEntity<TMessage, TCommand, TEvent, TRequest, TResponse> UsingQueueFor<T>(string queuePath, MessagingEntityCreationOptions creationOptions) where T : class, TMessage
         {
-            return UsingQueueFor<T>(queuePath, MessageReceiveMode.PeekLock, creationOptions);
+            return UsingQueueFor<T>(queuePath, MessageReceiveMode.ReceiveAndDelete, creationOptions);
         }
 
         public ICanSpecifyAzureServiceBusMessagingEntity<TMessage, TCommand, TEvent, TRequest, TResponse> UsingQueueFor<T>(string queuePath, MessageReceiveMode receiveMode, MessagingEntityCreationOptions creationOptions) where T : class, TMessage
@@ -246,7 +246,7 @@ namespace Obvs.AzureServiceBus.Configuration
 
         public ICanSpecifyAzureServiceBusMessagingEntity<TMessage, TCommand, TEvent, TRequest, TResponse> UsingSubscriptionFor<T>(string topicPath, string subscriptionName, MessagingEntityCreationOptions creationOptions) where T : class, TMessage
         {
-            return UsingSubscriptionFor<T>(topicPath, subscriptionName, MessageReceiveMode.PeekLock, creationOptions);
+            return UsingSubscriptionFor<T>(topicPath, subscriptionName, MessageReceiveMode.ReceiveAndDelete, creationOptions);
         }
 
         public ICanSpecifyAzureServiceBusMessagingEntity<TMessage, TCommand, TEvent, TRequest, TResponse> UsingSubscriptionFor<T>(string topicPath, string subscriptionName, MessageReceiveMode receiveMode, MessagingEntityCreationOptions creationOptions) where T : class, TMessage

--- a/Obvs.AzureServiceBus/Obvs.AzureServiceBus.nuspec
+++ b/Obvs.AzureServiceBus/Obvs.AzureServiceBus.nuspec
@@ -11,7 +11,7 @@
         <copyright>Copyright 2015</copyright>
         <tags>Azure Commands Events CQRS Rx Observable</tags>
         <releaseNotes>
-            * FIX: more changes to internal Rx stream management of BrokeredMessages inside MessageSource class
+            * BREAKING FIX: fluent config methods were using PeekLock as the default MessageReceiveMode, now using ReceiveAndDelete per documentation.
         </releaseNotes>
     </metadata>
 </package>

--- a/Obvs.AzureServiceBus/Properties/AssemblyInfo.cs
+++ b/Obvs.AzureServiceBus/Properties/AssemblyInfo.cs
@@ -14,8 +14,8 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-[assembly: AssemblyVersion("0.11.0.*")]
-[assembly: AssemblyInformationalVersion("0.11.0-beta")]
+[assembly: AssemblyVersion("0.12.0.*")]
+[assembly: AssemblyInformationalVersion("0.12.0-beta")]
 
 [assembly: InternalsVisibleTo("Obvs.AzureServiceBus.Tests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ As of Obvs 3.x, the framework offers no out-of-the-box control over peek-lock st
 Therefore this framework offers a small API-subset that is designed to be agnostic of Azure Service Bus at the surface level, yet gives you the 
 full control you would expect over peek-lock style messages as if you were working with Azure Service Bus's `BrokeredMessage` class directly.
 
-*Please note:* you must opt-in to `PeekLock` mode as the default is `ReceiveAndDelete`. This is to stay consistent with the Azure Service Bus API itself.
+**Please note:** you *must* opt-in to `PeekLock` mode as the default is `ReceiveAndDelete`. This is to stay consistent with the Azure Service Bus API itself.
 
 [You can read more on this subject here in the Wiki.](https://github.com/drub0y/Obvs.AzureServiceBus/wiki/Peek-Lock-Message-Processing-Pattern-Support)
 
@@ -83,6 +83,6 @@ serviceBusClient.Events.Subscribe(myEvent =>
     // ... handle the incoming event with whatever domain specific logic here ...
     
     // Signal completion of the peek lock
-    await myEvent.GetPeekLockControl().CompleteAsync();     
+    myEvent.GetPeekLockControl().CompleteAsync().Wait();     
 });
 ```


### PR DESCRIPTION
The documentation said it was `ReceiveAndDelete` by default and that was the original intention, but somewhere along the way I changed the fluent configuration APIs to default to `PeekLock`. This PR reverts those to `ReceiveAndDelete`.
