### PR TITLE
Marking PeekLockMessage as serializable.

### DIFF
--- a/Obvs.AzureServiceBus/Obvs.AzureServiceBus.nuspec
+++ b/Obvs.AzureServiceBus/Obvs.AzureServiceBus.nuspec
@@ -11,7 +11,7 @@
         <copyright>Copyright 2015</copyright>
         <tags>Azure Commands Events CQRS Rx Observable</tags>
         <releaseNotes>
-            * BREAKING FIX: fluent config methods were using PeekLock as the default MessageReceiveMode, now using ReceiveAndDelete per documentation.
+            * FIX: marking the PeekLockMessage base class with the SerializableAttribute and DataContractAttribute.
         </releaseNotes>
     </metadata>
 </package>

--- a/Obvs.AzureServiceBus/PeekLockMessage.cs
+++ b/Obvs.AzureServiceBus/PeekLockMessage.cs
@@ -6,6 +6,8 @@ using Obvs.Types;
 
 namespace Obvs.AzureServiceBus
 {
+    [DataContract]
+    [Serializable]
     public abstract class PeekLockMessage : IMessage
     {
         [NonSerialized]
@@ -30,7 +32,7 @@ namespace Obvs.AzureServiceBus
                 }
 
 #endif
-                
+
                 _messagePeekLockControl = value;
             }
         }

--- a/Obvs.AzureServiceBus/Properties/AssemblyInfo.cs
+++ b/Obvs.AzureServiceBus/Properties/AssemblyInfo.cs
@@ -14,8 +14,8 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-[assembly: AssemblyVersion("0.12.0.*")]
-[assembly: AssemblyInformationalVersion("0.12.0-beta")]
+[assembly: AssemblyVersion("0.13.0.*")]
+[assembly: AssemblyInformationalVersion("0.13.0-beta")]
 
 [assembly: InternalsVisibleTo("Obvs.AzureServiceBus.Tests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]


### PR DESCRIPTION
For some reason I forgot to apply the DataContractAttribute and SerializableAttribute to the PeekLockMessage class even though I marked its field/property as non-serialized.
