### PR TITLE
Message control via ConditionalWeaktable

### DIFF
--- a/Obvs.AzureServiceBus.Tests/MessagePropertiesFacts.cs
+++ b/Obvs.AzureServiceBus.Tests/MessagePropertiesFacts.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using FluentAssertions;
+using Moq;
+using Obvs.AzureServiceBus.Infrastructure;
+using Xunit;
+
+namespace Obvs.AzureServiceBus.Tests
+{
+    public class MessagePropertiesFacts
+    {
+        private Mock<IMessagePropertiesProvider> _mockMessagePropertiesProvider;
+        private Mock<IIncomingMessageProperties> _mockIncomingMessageProperties;
+        private Mock<IOutgoingMessageProperties> _mockOutgoingMessageProperties;
+
+        public MessagePropertiesFacts()
+        {
+            _mockMessagePropertiesProvider = new Mock<IMessagePropertiesProvider>();
+
+            _mockIncomingMessageProperties = new Mock<IIncomingMessageProperties>();
+            _mockOutgoingMessageProperties = new Mock<IOutgoingMessageProperties>();
+
+            _mockMessagePropertiesProvider.Setup(mpp => mpp.GetIncomingMessageProperties(It.IsAny<object>()))
+                .Returns(_mockIncomingMessageProperties.Object);
+
+            _mockMessagePropertiesProvider.Setup(mpp => mpp.GetOutgoingMessageProperties(It.IsAny<object>()))
+                .Returns(_mockOutgoingMessageProperties.Object);
+
+            MessagePropertiesProvider.Use(_mockMessagePropertiesProvider.Object);
+        }
+
+        public class GetIncomingPropertiesFacts : MessagePropertiesFacts
+        {
+            [Fact]
+            public void AttemptingToGetIncomingMessagePropertiesForNullMessageThrows()
+            {
+                TestMessage message = null;
+
+                Action action = () => message.GetIncomingMessageProperties();
+
+                action.ShouldThrow<ArgumentNullException>()
+                    .And.ParamName.Should().Be("message");
+            }
+
+            [Fact]
+            public void GetIncomingMessagePropertiesForMessageInvokesProvider()
+            {
+                TestMessage testMessage = new TestMessage();
+
+                testMessage.GetIncomingMessageProperties();
+
+                _mockMessagePropertiesProvider.Verify(mplcp => mplcp.GetIncomingMessageProperties(testMessage), Times.Once());
+            }
+
+            [Fact]
+            public void GetIncomingMessagePropertiesForMessageReturnsExpectedInstance()
+            {
+                new TestMessage().GetIncomingMessageProperties().Should().Be(_mockIncomingMessageProperties.Object);
+            }
+        }
+
+        public class GetOutgoingPropertiesFacts : MessagePropertiesFacts
+        {
+            [Fact]
+            public void AttemptingToGetOutgoingMessagePropertiesForNullMessageThrows()
+            {
+                TestMessage message = null;
+
+                Action action = () => message.GetOutgoingMessageProperties();
+
+                action.ShouldThrow<ArgumentNullException>()
+                    .And.ParamName.Should().Be("message");
+            }
+
+            [Fact]
+            public void GetOutgoingMessagePropertiesForMessageInvokesProvider()
+            {
+                TestMessage testMessage = new TestMessage();
+
+                testMessage.GetOutgoingMessageProperties();
+
+                _mockMessagePropertiesProvider.Verify(mplcp => mplcp.GetOutgoingMessageProperties(testMessage), Times.Once());
+            }
+
+            [Fact]
+            public void GetOutgoingMessagePropertiesForMessageReturnsExpectedInstance()
+            {
+                new TestMessage().GetOutgoingMessageProperties().Should().Be(_mockOutgoingMessageProperties.Object);
+            }
+        }
+
+        internal class TestMessage
+        {
+        }
+    }
+}

--- a/Obvs.AzureServiceBus.Tests/MessageSourceFacts.cs
+++ b/Obvs.AzureServiceBus.Tests/MessageSourceFacts.cs
@@ -240,7 +240,7 @@ namespace Obvs.AzureServiceBus.Tests
                 mockPeekLockControlProvider.Setup(bmplcp => bmplcp.GetMessagePeekLockControl(testPeekLockMessage))
                     .Returns(mockBrokeredMessagePeekLockControl.Object);
 
-                MessagePeekLockControlProvider.Default = mockPeekLockControlProvider.Object;
+                MessagePeekLockControlProvider.Use(mockPeekLockControlProvider.Object);
 
                 MessageSource<TestPeekLockMessage> messageSource = new MessageSource<TestPeekLockMessage>(brokeredMessages, new[] { mockTestPeekLockMessageDeserializer.Object }, Mock.Of<IMessageBrokeredMessageTable>());
 

--- a/Obvs.AzureServiceBus.Tests/Obvs.AzureServiceBus.Tests.csproj
+++ b/Obvs.AzureServiceBus.Tests/Obvs.AzureServiceBus.Tests.csproj
@@ -112,6 +112,7 @@
     <Compile Include="MessagingEntityVerifierFacts.cs" />
     <Compile Include="ConfigurationFacts.cs" />
     <Compile Include="MessagePublisherFacts.cs" />
+    <Compile Include="MessagePropertiesFacts.cs" />
     <Compile Include="PeekLockMessageControlFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="MessageSourceFacts.cs" />

--- a/Obvs.AzureServiceBus.Tests/PeekLockMessageControlFacts.cs
+++ b/Obvs.AzureServiceBus.Tests/PeekLockMessageControlFacts.cs
@@ -15,7 +15,7 @@ namespace Obvs.AzureServiceBus.Tests
             mockMessagePeekLockControlProvider.Setup(mplcp => mplcp.GetMessagePeekLockControl<TestMessage>(It.IsAny<TestMessage>()))
                 .Returns(Mock.Of<IMessagePeekLockControl>());
 
-            MessagePeekLockControlProvider.Default = mockMessagePeekLockControlProvider.Object;
+            MessagePeekLockControlProvider.Use(mockMessagePeekLockControlProvider.Object);
         }
 
         public class GetPeekLockControl : PeekLockMessageControlFacts

--- a/Obvs.AzureServiceBus.Tests/PeekLockMessageControlFacts.cs
+++ b/Obvs.AzureServiceBus.Tests/PeekLockMessageControlFacts.cs
@@ -1,24 +1,29 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using Obvs.AzureServiceBus.Infrastructure;
 using Obvs.Types;
 using Xunit;
-using FluentAssertions;
-using Obvs.AzureServiceBus;
-using Moq;
 
 namespace Obvs.AzureServiceBus.Tests
 {
     public class PeekLockMessageControlFacts
     {
-        public class GetPeekLockControl
+        public PeekLockMessageControlFacts()
+        {
+            Mock<IMessagePeekLockControlProvider> mockMessagePeekLockControlProvider = new Mock<IMessagePeekLockControlProvider>();
+            mockMessagePeekLockControlProvider.Setup(mplcp => mplcp.GetMessagePeekLockControl<TestMessage>(It.IsAny<TestMessage>()))
+                .Returns(Mock.Of<IMessagePeekLockControl>());
+
+            MessagePeekLockControlProvider.Default = mockMessagePeekLockControlProvider.Object;
+        }
+
+        public class GetPeekLockControl : PeekLockMessageControlFacts
         {
             [Fact]
             public void AttemptingToGetPeekLockControlForNullMessageThrows()
             {
-                IMessage message = null;
+                TestMessage message = null;
 
                 Action action = () => message.GetPeekLockControl();
 
@@ -27,15 +32,14 @@ namespace Obvs.AzureServiceBus.Tests
             }
 
             [Fact]
-            public void AttemptingToGetPeekLockControlForNonPeekLockBasedMessageThrows()
+            public void GetPeekLockControlForMessageReturnsNonNullInstance()
             {
-                IMessage message = Mock.Of<IMessage>();
-
-                Action action = () => message.GetPeekLockControl();
-
-                action.ShouldThrow<InvalidOperationException>();
+                new TestMessage().GetPeekLockControl().Should().NotBeNull();
             }
         }
 
+        internal class TestMessage
+        {
+        }
     }
 }

--- a/Obvs.AzureServiceBus/Configuration/AzureServiceBusEndpointProvider.cs
+++ b/Obvs.AzureServiceBus/Configuration/AzureServiceBusEndpointProvider.cs
@@ -108,7 +108,7 @@ namespace Obvs.AzureServiceBus.Configuration
                     typeof(IMessageDeserializerFactory).GetMethod("Create").MakeGenericMethod(messageType, typeof(TServiceMessage)),
                     Expression.Constant(_assemblyFilter, typeof(Func<Assembly, bool>)),
                     Expression.Constant(_typeFilter, typeof(Func<Type, bool>))),
-                Expression.Constant(MessageBrokeredMessageTable.Default, typeof(IMessageBrokeredMessageTable)))).Compile().Invoke();
+                Expression.Constant(MessageBrokeredMessageTable.ConfiguredInstance, typeof(IMessageBrokeredMessageTable)))).Compile().Invoke();
         }
     }
 }

--- a/Obvs.AzureServiceBus/Configuration/AzureServiceBusFluentConfig.cs
+++ b/Obvs.AzureServiceBus/Configuration/AzureServiceBusFluentConfig.cs
@@ -79,7 +79,15 @@ namespace Obvs.AzureServiceBus.Configuration
         ICanSpecifyAzureServiceBusMessagingEntity<TMessage, TCommand, TEvent, TRequest, TResponse> UsingSubscriptionFor<T>(string topicPath, string subscriptionName, MessageReceiveMode receiveMode, MessagingEntityCreationOptions creationOptions) where T : class, TMessage;
     }
 
-    internal class AzureServiceBusFluentConfig<TServiceMessage, TMessage, TCommand, TEvent, TRequest, TResponse> : ICanAddAzureServiceBusServiceName<TMessage, TCommand, TEvent, TRequest, TResponse>, ICanSpecifyAzureServiceBusNamespace<TMessage, TCommand, TEvent, TRequest, TResponse>, ICanSpecifyAzureServiceBusMessagingFactory<TMessage, TCommand, TEvent, TRequest, TResponse>, ICanSpecifyAzureServiceBusMessagingEntity<TMessage, TCommand, TEvent, TRequest, TResponse>, ICanCreateEndpointAsClientOrServer<TMessage, TCommand, TEvent, TRequest, TResponse>, ICanSpecifyEndpointSerializers<TMessage, TCommand, TEvent, TRequest, TResponse>, ICanSpecifyAzureServiceBusMessagingEntityVerifier<TMessage, TCommand, TEvent, TRequest, TResponse>, ICanSpecifyPropertyProviders<TMessage, TCommand, TEvent, TRequest, TResponse>
+    internal class AzureServiceBusFluentConfig<TServiceMessage, TMessage, TCommand, TEvent, TRequest, TResponse> :
+        ICanAddAzureServiceBusServiceName<TMessage, TCommand, TEvent, TRequest, TResponse>,
+        ICanSpecifyAzureServiceBusNamespace<TMessage, TCommand, TEvent, TRequest, TResponse>,
+        ICanSpecifyAzureServiceBusMessagingFactory<TMessage, TCommand, TEvent, TRequest, TResponse>,
+        ICanSpecifyAzureServiceBusMessagingEntity<TMessage, TCommand, TEvent, TRequest, TResponse>,
+        ICanCreateEndpointAsClientOrServer<TMessage, TCommand, TEvent, TRequest, TResponse>,
+        ICanSpecifyEndpointSerializers<TMessage, TCommand, TEvent, TRequest, TResponse>,
+        ICanSpecifyAzureServiceBusMessagingEntityVerifier<TMessage, TCommand, TEvent, TRequest, TResponse>,
+        ICanSpecifyPropertyProviders<TMessage, TCommand, TEvent, TRequest, TResponse>
         where TMessage : class
         where TCommand : class, TMessage
         where TEvent : class, TMessage
@@ -107,6 +115,7 @@ namespace Obvs.AzureServiceBus.Configuration
         public ICanSpecifyAzureServiceBusNamespace<TMessage, TCommand, TEvent, TRequest, TResponse> Named(string serviceName)
         {
             _serviceName = serviceName;
+
             return this;
         }
 
@@ -140,27 +149,28 @@ namespace Obvs.AzureServiceBus.Configuration
             _messagingEntityVerifier.EnsureMessagingEntitiesExist(_messageTypePathMappings);
 
             return new AzureServiceBusEndpointProvider<TServiceMessage, TMessage, TCommand, TEvent, TRequest, TResponse>(_serviceName, _messagingFactory, _serializer, _deserializerFactory, _messageTypePathMappings, _assemblyFilter, _typeFilter, _messagePropertyProviderManager);
-        }        
+        }
 
         public ICanSpecifyAzureServiceBusMessagingFactory<TMessage, TCommand, TEvent, TRequest, TResponse> WithConnectionString(string connectionString)
         {
             if(connectionString == null) throw new ArgumentNullException("connectionString");
-            
+
             return WithNamespaceManager(NamespaceManager.CreateFromConnectionString(connectionString));
         }
 
         public ICanSpecifyAzureServiceBusMessagingFactory<TMessage, TCommand, TEvent, TRequest, TResponse> WithNamespaceManager(INamespaceManager namespaceManager)
         {
             if(namespaceManager == null) throw new ArgumentNullException("namespaceManager");
-            
+
             _namespaceManager = namespaceManager;
+
             return this;
         }
 
         public ICanSpecifyAzureServiceBusMessagingFactory<TMessage, TCommand, TEvent, TRequest, TResponse> WithNamespaceManager(NamespaceManager namespaceManager)
         {
             if(namespaceManager == null) throw new ArgumentNullException("namespaceManager");
-            
+
             return WithNamespaceManager(new NamespaceManagerWrapper(namespaceManager));
         }
 
@@ -168,8 +178,9 @@ namespace Obvs.AzureServiceBus.Configuration
         public ICanSpecifyAzureServiceBusMessagingEntityVerifier<TMessage, TCommand, TEvent, TRequest, TResponse> WithMessagingFactory(IMessagingFactory messagingFactory)
         {
             if(messagingFactory == null) throw new ArgumentNullException("messagingFactory");
-            
+
             _messagingFactory = messagingFactory;
+
             return this;
         }
 
@@ -183,6 +194,7 @@ namespace Obvs.AzureServiceBus.Configuration
             if(messagingEntityVerifier == null) throw new ArgumentNullException("messagingEntityVerifier");
 
             _messagingEntityVerifier = messagingEntityVerifier;
+
             return this;
         }
 
@@ -190,6 +202,7 @@ namespace Obvs.AzureServiceBus.Configuration
         {
             _serializer = serializer;
             _deserializerFactory = deserializerFactory;
+
             return this;
         }
 
@@ -197,6 +210,7 @@ namespace Obvs.AzureServiceBus.Configuration
         {
             _assemblyFilter = assemblyFilter;
             _typeFilter = typeFilter;
+
             return this;
         }
 
@@ -218,7 +232,7 @@ namespace Obvs.AzureServiceBus.Configuration
         public ICanSpecifyAzureServiceBusMessagingEntity<TMessage, TCommand, TEvent, TRequest, TResponse> UsingQueueFor<T>(string queuePath, MessageReceiveMode receiveMode, MessagingEntityCreationOptions creationOptions) where T : class, TMessage
         {
             AddMessageTypePathMapping(new MessageTypeMessagingEntityMappingDetails(typeof(T), queuePath, MessagingEntityType.Queue, creationOptions, receiveMode));
-            
+
             return this;
         }
 
@@ -266,6 +280,7 @@ namespace Obvs.AzureServiceBus.Configuration
 
             return this;
         }
+
         private void AddMessageTypePathMapping(MessageTypeMessagingEntityMappingDetails messageTypePathMappingDetails)
         {
             MessageTypeMessagingEntityMappingDetails existingMessageTypePathMapping = _messageTypePathMappings.FirstOrDefault(mtpm => mtpm.MessageType == messageTypePathMappingDetails.MessageType && mtpm.MessagingEntityType == messageTypePathMappingDetails.MessagingEntityType);

--- a/Obvs.AzureServiceBus/Infrastructure/IMessageBrokeredMessageTable.cs
+++ b/Obvs.AzureServiceBus/Infrastructure/IMessageBrokeredMessageTable.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using Microsoft.ServiceBus.Messaging;
+
+namespace Obvs.AzureServiceBus.Infrastructure
+{
+    internal interface IMessageBrokeredMessageTable
+    {
+        void SetBrokeredMessageForMessage(object message, BrokeredMessage brokeredMessage);
+
+        BrokeredMessage GetBrokeredMessageForMessage(object message);
+
+        void RemoveBrokeredMessageForMessage(object message);
+    }
+
+    internal sealed class MessageBrokeredMessageTable
+    {
+        public static IMessageBrokeredMessageTable Default = new DefaultMessageBrokeredMessageTable();
+    }
+
+    internal sealed class DefaultMessageBrokeredMessageTable : IMessageBrokeredMessageTable
+    {
+        ConditionalWeakTable<object, BrokeredMessage> _innerTable = new ConditionalWeakTable<object, BrokeredMessage>();
+
+        public void SetBrokeredMessageForMessage(object message, BrokeredMessage brokeredMessage)
+        {
+            if(message == null) throw new ArgumentNullException(nameof(message));
+            if(brokeredMessage == null) throw new ArgumentNullException(nameof(brokeredMessage));
+
+            _innerTable.Add(message, brokeredMessage);
+        }
+
+        public BrokeredMessage GetBrokeredMessageForMessage(object message)
+        {
+            BrokeredMessage brokeredMessage;
+
+            _innerTable.TryGetValue(message, out brokeredMessage);
+
+            return brokeredMessage;
+        }
+
+        public void RemoveBrokeredMessageForMessage(object message)
+        {
+            _innerTable.Remove(message);
+        }
+    }
+}

--- a/Obvs.AzureServiceBus/Infrastructure/IMessageBrokeredMessageTable.cs
+++ b/Obvs.AzureServiceBus/Infrastructure/IMessageBrokeredMessageTable.cs
@@ -15,7 +15,15 @@ namespace Obvs.AzureServiceBus.Infrastructure
 
     internal sealed class MessageBrokeredMessageTable
     {
-        public static IMessageBrokeredMessageTable Default = new DefaultMessageBrokeredMessageTable();
+        private static readonly IMessageBrokeredMessageTable Instance = new DefaultMessageBrokeredMessageTable();
+
+        public static IMessageBrokeredMessageTable ConfiguredInstance
+        {
+            get
+            {
+                return Instance;
+            }
+        }
     }
 
     internal sealed class DefaultMessageBrokeredMessageTable : IMessageBrokeredMessageTable

--- a/Obvs.AzureServiceBus/Infrastructure/MessagePropertiesProvider.cs
+++ b/Obvs.AzureServiceBus/Infrastructure/MessagePropertiesProvider.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using Microsoft.ServiceBus.Messaging;
+
+namespace Obvs.AzureServiceBus.Infrastructure
+{
+    internal static class MessagePropertiesProvider
+    {
+        public static IMessagePropertiesProvider Default;
+    }
+
+    internal interface IMessagePropertiesProvider
+    {
+        IIncomingMessageProperties GetIncomingMessageProperties(object message);
+        IOutgoingMessageProperties GetOutgoingMessageProperties(object message);
+    }
+
+    internal sealed class DefaultBrokeredMessagePropertiesProvider : IMessagePropertiesProvider
+    {
+        private IMessageBrokeredMessageTable _messageBrokeredMessageTable;
+
+        public DefaultBrokeredMessagePropertiesProvider(IMessageBrokeredMessageTable messageBrokeredMessageTable)
+        {
+            _messageBrokeredMessageTable = messageBrokeredMessageTable;
+        }
+
+        public IIncomingMessageProperties GetIncomingMessageProperties(object message) => new DefaultBrokeredMessageIncomingMessageProperties(_messageBrokeredMessageTable.GetBrokeredMessageForMessage(message));
+
+        public IOutgoingMessageProperties GetOutgoingMessageProperties(object message) => new DefaultBrokeredMessageOutgoingMessageProperties(_messageBrokeredMessageTable.GetBrokeredMessageForMessage(message));
+    }
+
+    public interface IIncomingMessageProperties
+    {
+        int DeliveryCount
+        {
+            get;
+        }
+    }
+
+    public interface IOutgoingMessageProperties
+    {
+        DateTime ScheduledEnqueueTimeUtc
+        {
+            get;
+            set;
+        }
+
+        TimeSpan TimeToLive
+        {
+            get;
+            set;
+        }
+    }
+
+    internal struct DefaultBrokeredMessageIncomingMessageProperties : IIncomingMessageProperties
+    {
+        private BrokeredMessage _brokeredMessage;
+
+        public DefaultBrokeredMessageIncomingMessageProperties(BrokeredMessage brokeredMessage)
+        {
+            _brokeredMessage = brokeredMessage;
+        }
+
+        public int DeliveryCount
+        {
+            get
+            {
+                return _brokeredMessage.DeliveryCount;
+            }
+        }
+    }
+
+    internal struct DefaultBrokeredMessageOutgoingMessageProperties : IOutgoingMessageProperties
+    {
+        private BrokeredMessage _brokeredMessage;
+
+        public DefaultBrokeredMessageOutgoingMessageProperties(BrokeredMessage brokeredMessage)
+        {
+            _brokeredMessage = brokeredMessage;
+        }
+
+        public DateTime ScheduledEnqueueTimeUtc
+        {
+            get
+            {
+                return _brokeredMessage.ScheduledEnqueueTimeUtc;
+            }
+            set
+            {
+                _brokeredMessage.ScheduledEnqueueTimeUtc = value;
+            }
+        }
+
+        public TimeSpan TimeToLive
+        {
+            get
+            {
+                return _brokeredMessage.TimeToLive;
+            }
+
+            set
+            {
+                _brokeredMessage.TimeToLive = value;
+            }
+        }
+    }
+}

--- a/Obvs.AzureServiceBus/Infrastructure/PeekLockMessageControl.cs
+++ b/Obvs.AzureServiceBus/Infrastructure/PeekLockMessageControl.cs
@@ -6,7 +6,29 @@ namespace Obvs.AzureServiceBus.Infrastructure
 {
     public static class MessagePeekLockControlProvider
     {
-        public static IMessagePeekLockControlProvider Default;
+        private static IMessagePeekLockControlProvider Instance;
+
+        internal static IMessagePeekLockControlProvider ConfiguredInstance
+        {
+            get
+            {
+                if(Instance == null)
+                {
+                    UseDefault();
+                }
+
+                return Instance;
+            }
+        }
+
+        public static void Use(IMessagePeekLockControlProvider messagePeekLockControlProvider)
+        {
+            MessagePeekLockControlProvider.Instance = messagePeekLockControlProvider;
+        }
+
+        public static void UseDefault() => Use(new DefaultBrokeredMessagePeekLockControlProvider(MessageBrokeredMessageTable.ConfiguredInstance));
+
+        public static void UseFakeMessagePeekLockControlProvider() => Use(new FakeMessagePeekLockControlProvider());
     }
 
     public interface IMessagePeekLockControl
@@ -32,55 +54,66 @@ namespace Obvs.AzureServiceBus.Infrastructure
         }
 
         public IMessagePeekLockControl GetMessagePeekLockControl<TMessage>(TMessage message) => new DefaultBrokeredMessagePeekLockControl(_messageBrokeredMessageTable.GetBrokeredMessageForMessage(message));
-    }
 
-    internal struct DefaultBrokeredMessagePeekLockControl : IMessagePeekLockControl
-    {
-        private BrokeredMessage _brokeredMessage;
-
-        public DefaultBrokeredMessagePeekLockControl(BrokeredMessage brokeredMessage)
+        private sealed class DefaultBrokeredMessagePeekLockControl : IMessagePeekLockControl
         {
-            _brokeredMessage = brokeredMessage;
-        }
+            private BrokeredMessage _brokeredMessage;
 
-        public async Task AbandonAsync()
-        {
-            await PerformBrokeredMessageActionAndDisposeAsync(async bm => await bm.AbandonAsync());
-        }
-
-        public async Task CompleteAsync()
-        {
-            await PerformBrokeredMessageActionAndDisposeAsync(async bm => await bm.CompleteAsync());
-        }
-
-        public async Task RejectAsync(string reasonCode, string description)
-        {
-            await PerformBrokeredMessageActionAndDisposeAsync(async bm => await bm.DeadLetterAsync(reasonCode, description));
-        }
-
-        public Task RenewLockAsync()
-        {
-            EnsureBrokeredMessageNotAlreadyProcessed();
-
-            return _brokeredMessage.RenewLockAsync();
-        }
-
-        private async Task PerformBrokeredMessageActionAndDisposeAsync(Func<BrokeredMessage, Task> action)
-        {
-            EnsureBrokeredMessageNotAlreadyProcessed();
-
-            await action(_brokeredMessage);
-
-            _brokeredMessage.Dispose();
-            _brokeredMessage = null;
-        }
-
-        private void EnsureBrokeredMessageNotAlreadyProcessed()
-        {
-            if(_brokeredMessage == null)
+            public DefaultBrokeredMessagePeekLockControl(BrokeredMessage brokeredMessage)
             {
-                throw new InvalidOperationException("The message has already been abandoned, completed or rejected.");
+                _brokeredMessage = brokeredMessage;
+            }
+
+            public async Task AbandonAsync() => await PerformBrokeredMessageActionAndDisposeAsync(async bm => await bm.AbandonAsync());
+
+            public async Task CompleteAsync() => await PerformBrokeredMessageActionAndDisposeAsync(async bm => await bm.CompleteAsync());
+
+            public async Task RejectAsync(string reasonCode, string description) => await PerformBrokeredMessageActionAndDisposeAsync(async bm => await bm.DeadLetterAsync(reasonCode, description));
+
+            public Task RenewLockAsync()
+            {
+                EnsureBrokeredMessageNotAlreadyProcessed();
+
+                return _brokeredMessage.RenewLockAsync();
+            }
+
+            private async Task PerformBrokeredMessageActionAndDisposeAsync(Func<BrokeredMessage, Task> action)
+            {
+                EnsureBrokeredMessageNotAlreadyProcessed();
+
+                await action(_brokeredMessage);
+
+                _brokeredMessage.Dispose();
+                _brokeredMessage = null;
+            }
+
+            private void EnsureBrokeredMessageNotAlreadyProcessed()
+            {
+                if(_brokeredMessage == null)
+                {
+                    throw new InvalidOperationException("The message has already been abandoned, completed or rejected.");
+                }
             }
         }
     }
+
+    internal sealed class FakeMessagePeekLockControlProvider : IMessagePeekLockControlProvider
+    {
+        public IMessagePeekLockControl GetMessagePeekLockControl<TMessage>(TMessage message) => FakeMessagePeekLockControl.Default;
+
+        private sealed class FakeMessagePeekLockControl : IMessagePeekLockControl
+        {
+            public static readonly FakeMessagePeekLockControl Default = new FakeMessagePeekLockControl();
+            private static readonly Task CompletedPeekLockOperationTask = Task.FromResult<object>(null);
+
+            public Task AbandonAsync() => FakeMessagePeekLockControl.CompletedPeekLockOperationTask;
+
+            public Task CompleteAsync() => FakeMessagePeekLockControl.CompletedPeekLockOperationTask;
+
+            public Task RejectAsync(string reasonCode, string description) => FakeMessagePeekLockControl.CompletedPeekLockOperationTask;
+
+            public Task RenewLockAsync() => FakeMessagePeekLockControl.CompletedPeekLockOperationTask;
+        }
+    }
+
 }

--- a/Obvs.AzureServiceBus/MessagePropertiesMessageExtensions.cs
+++ b/Obvs.AzureServiceBus/MessagePropertiesMessageExtensions.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using Obvs.AzureServiceBus.Infrastructure;
+
+namespace Obvs.AzureServiceBus
+{
+    public static class MessagePropertiesMessageExtensions
+    {
+        public static IOutgoingMessageProperties GetOutgoingMessageProperties<TMessage>(this TMessage message) where TMessage : class
+        {
+            if(message == null) throw new ArgumentNullException(nameof(message));
+
+            IMessagePropertiesProvider configuredMessagePropertyProvider = MessagePropertiesProvider.Default;
+
+            if(configuredMessagePropertyProvider == null)
+            {
+                throw new InvalidOperationException($"No {nameof(IMessagePropertiesProvider)} has been configured.");
+            }
+
+            return configuredMessagePropertyProvider.GetOutgoingMessageProperties(message);
+        }
+
+        public static IIncomingMessageProperties GetIncomingMessageProperties<TMessage>(this TMessage message) where TMessage : class
+        {
+            if(message == null) throw new ArgumentNullException(nameof(message));
+
+            IMessagePropertiesProvider configuredMessagePropertyProvider = MessagePropertiesProvider.Default;
+
+            if(configuredMessagePropertyProvider == null)
+            {
+                throw new InvalidOperationException($"No {nameof(IMessagePropertiesProvider)} has been configured.");
+            }
+
+            return configuredMessagePropertyProvider.GetIncomingMessageProperties(message);
+        }
+    }
+}

--- a/Obvs.AzureServiceBus/MessagePropertiesMessageExtensions.cs
+++ b/Obvs.AzureServiceBus/MessagePropertiesMessageExtensions.cs
@@ -5,32 +5,22 @@ namespace Obvs.AzureServiceBus
 {
     public static class MessagePropertiesMessageExtensions
     {
-        public static IOutgoingMessageProperties GetOutgoingMessageProperties<TMessage>(this TMessage message) where TMessage : class
+        public static IOutgoingMessageProperties GetOutgoingMessageProperties<TMessage>(this TMessage message) where TMessage : class => ValidateMessageAndGetConfiguredMessagePropertyProvider(message).GetOutgoingMessageProperties(message);
+
+        public static IIncomingMessageProperties GetIncomingMessageProperties<TMessage>(this TMessage message) where TMessage : class => ValidateMessageAndGetConfiguredMessagePropertyProvider(message).GetIncomingMessageProperties(message);
+
+        private static IMessagePropertiesProvider ValidateMessageAndGetConfiguredMessagePropertyProvider<TMessage>(TMessage message) where TMessage : class
         {
             if(message == null) throw new ArgumentNullException(nameof(message));
 
-            IMessagePropertiesProvider configuredMessagePropertyProvider = MessagePropertiesProvider.Default;
+            IMessagePropertiesProvider configuredMessagePropertyProvider = MessagePropertiesProvider.ConfiguredInstance;
 
             if(configuredMessagePropertyProvider == null)
             {
                 throw new InvalidOperationException($"No {nameof(IMessagePropertiesProvider)} has been configured.");
             }
 
-            return configuredMessagePropertyProvider.GetOutgoingMessageProperties(message);
-        }
-
-        public static IIncomingMessageProperties GetIncomingMessageProperties<TMessage>(this TMessage message) where TMessage : class
-        {
-            if(message == null) throw new ArgumentNullException(nameof(message));
-
-            IMessagePropertiesProvider configuredMessagePropertyProvider = MessagePropertiesProvider.Default;
-
-            if(configuredMessagePropertyProvider == null)
-            {
-                throw new InvalidOperationException($"No {nameof(IMessagePropertiesProvider)} has been configured.");
-            }
-
-            return configuredMessagePropertyProvider.GetIncomingMessageProperties(message);
+            return configuredMessagePropertyProvider;
         }
     }
 }

--- a/Obvs.AzureServiceBus/Obvs.AzureServiceBus.csproj
+++ b/Obvs.AzureServiceBus/Obvs.AzureServiceBus.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Configuration\AzureServiceBusFluentConfig.cs" />
     <Compile Include="Configuration\ConfigurationUtilities.cs" />
     <Compile Include="Configuration\MessageTypeMessagingEntityMappingDetails.cs" />
+    <Compile Include="Infrastructure\IMessageBrokeredMessageTable.cs" />
     <Compile Include="Infrastructure\IMessagingEntityFactory.cs" />
     <Compile Include="Infrastructure\IMessagingEntityVerifier.cs" />
     <Compile Include="Infrastructure\MessagingEntityVerifier.cs" />

--- a/Obvs.AzureServiceBus/Obvs.AzureServiceBus.csproj
+++ b/Obvs.AzureServiceBus/Obvs.AzureServiceBus.csproj
@@ -76,6 +76,7 @@
     <Compile Include="Infrastructure\IMessageBrokeredMessageTable.cs" />
     <Compile Include="Infrastructure\IMessagingEntityFactory.cs" />
     <Compile Include="Infrastructure\IMessagingEntityVerifier.cs" />
+    <Compile Include="Infrastructure\MessagePropertiesProvider.cs" />
     <Compile Include="Infrastructure\MessagingEntityVerifier.cs" />
     <Compile Include="Infrastructure\PeekLockMessageControl.cs" />
     <Compile Include="Infrastructure\MessageEntityFactory.cs" />
@@ -89,6 +90,7 @@
     <Compile Include="Infrastructure\INamespaceManager.cs" />
     <Compile Include="Infrastructure\IMessageSender.cs" />
     <Compile Include="Infrastructure\MessageSenderWrapper.cs" />
+    <Compile Include="MessagePropertiesMessageExtensions.cs" />
     <Compile Include="MessagePublisher.cs" />
     <Compile Include="MessageSource.cs" />
     <Compile Include="PeekLockControlMessageExtensions.cs" />

--- a/Obvs.AzureServiceBus/Obvs.AzureServiceBus.nuspec
+++ b/Obvs.AzureServiceBus/Obvs.AzureServiceBus.nuspec
@@ -11,16 +11,8 @@
         <copyright>Copyright 2015</copyright>
         <tags>Azure Commands Events CQRS Rx Observable</tags>
         <releaseNotes>
-            BREAKING CHANGE:
-
-            This release removes the requirement of inheriting from the PeekLockMessage class in order to gain
-            control over peek lock messages. The class itself has been removed entirely, but there are effectively
-            no other external API changes. Upon upgrading to this version of the library the only change you
-            should have to make is to remove PeekLockMessage as a base class wherever it was being used.
-
-            Another positive side effect of this change is that you may also be able to remove references to
-            the Obvs.AzureServiceBus library and all of its dependencies from some of your projects since it
-            no longer requires polution of your domain type hierarchy.
+            * Introduction of incoming/outgoing AzureSB transport specific message properties support via GetIncoming/OutgoingMessageProperties extension methods (details here: https://github.com/drub0y/Obvs.AzureServiceBus/wiki/Accessing-Azure-Service-Bus-specific-message-properties)
+            * Various internal refactorings of how messages are mapped to their underlying AzureSB BrokeredMessages (details here: https://github.com/drub0y/Obvs.AzureServiceBus/pull/17)
         </releaseNotes>
     </metadata>
 </package>

--- a/Obvs.AzureServiceBus/PeekLockControlMessageExtensions.cs
+++ b/Obvs.AzureServiceBus/PeekLockControlMessageExtensions.cs
@@ -9,7 +9,7 @@ namespace Obvs.AzureServiceBus
         {
             if(message == null) throw new ArgumentNullException(nameof(message));
 
-            IMessagePeekLockControlProvider configuredMessagePeekLockControlProvider = MessagePeekLockControlProvider.Default;
+            IMessagePeekLockControlProvider configuredMessagePeekLockControlProvider = MessagePeekLockControlProvider.ConfiguredInstance;
 
             if(configuredMessagePeekLockControlProvider == null)
             {

--- a/Obvs.AzureServiceBus/PeekLockControlMessageExtensions.cs
+++ b/Obvs.AzureServiceBus/PeekLockControlMessageExtensions.cs
@@ -13,17 +13,10 @@ namespace Obvs.AzureServiceBus
 
             if(configuredMessagePeekLockControlProvider == null)
             {
-                throw new InvalidOperationException($"No {nameof(IMessagePeekLockControlProvider)} has been configured."); 
+                throw new InvalidOperationException($"No {nameof(IMessagePeekLockControlProvider)} has been configured.");
             }
 
-            IMessagePeekLockControl result = configuredMessagePeekLockControlProvider.GetMessagePeekLockControl(message);
-
-            if(result == null)
-            {
-                throw new InvalidOperationException("The specified message is not being tracked for peek lock control.");
-            }
-
-            return result;
+            return configuredMessagePeekLockControlProvider.GetMessagePeekLockControl(message);
         }
     }
 }

--- a/Obvs.AzureServiceBus/Properties/AssemblyInfo.cs
+++ b/Obvs.AzureServiceBus/Properties/AssemblyInfo.cs
@@ -14,8 +14,8 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-[assembly: AssemblyVersion("0.14.0.*")]
-[assembly: AssemblyInformationalVersion("0.14.0-beta2")]
+[assembly: AssemblyVersion("0.15.0.*")]
+[assembly: AssemblyInformationalVersion("0.15.0-beta2")]
 
 [assembly: InternalsVisibleTo("Obvs.AzureServiceBus.Tests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]


### PR DESCRIPTION
This PR expands on the original work of using ConditionalWeaktable just for message peek lock control by centralizing the mapping of message<->brokeredmessage via a shared mechanism that allows other functionality to be around it.
- Peek lock message control has be reworked to use the shared mapping
- Introducing initial support for accessing incoming/outgoing message properties via extension methods
