### PR TITLE
Fixing bug wher getting outgoing message properties would result in NRE

### DIFF
--- a/Obvs.AzureServiceBus/Infrastructure/IMessageBrokeredMessageTable.cs
+++ b/Obvs.AzureServiceBus/Infrastructure/IMessageBrokeredMessageTable.cs
@@ -38,18 +38,8 @@ namespace Obvs.AzureServiceBus.Infrastructure
             _innerTable.Add(message, brokeredMessage);
         }
 
-        public BrokeredMessage GetBrokeredMessageForMessage(object message)
-        {
-            BrokeredMessage brokeredMessage;
+        public BrokeredMessage GetBrokeredMessageForMessage(object message) => _innerTable.GetOrCreateValue(message);
 
-            _innerTable.TryGetValue(message, out brokeredMessage);
-
-            return brokeredMessage;
-        }
-
-        public void RemoveBrokeredMessageForMessage(object message)
-        {
-            _innerTable.Remove(message);
-        }
+        public void RemoveBrokeredMessageForMessage(object message) => _innerTable.Remove(message);
     }
 }

--- a/Obvs.AzureServiceBus/Obvs.AzureServiceBus.nuspec
+++ b/Obvs.AzureServiceBus/Obvs.AzureServiceBus.nuspec
@@ -11,8 +11,7 @@
         <copyright>Copyright 2015</copyright>
         <tags>Azure Commands Events CQRS Rx Observable</tags>
         <releaseNotes>
-            * Introduction of incoming/outgoing AzureSB transport specific message properties support via GetIncoming/OutgoingMessageProperties extension methods (details here: https://github.com/drub0y/Obvs.AzureServiceBus/wiki/Accessing-Azure-Service-Bus-specific-message-properties)
-            * Various internal refactorings of how messages are mapped to their underlying AzureSB BrokeredMessages (details here: https://github.com/drub0y/Obvs.AzureServiceBus/pull/17)
+            FIX: fixing bug where getting outgoing message properties for a newly created message would result in a NullReferenceException.
         </releaseNotes>
     </metadata>
 </package>

--- a/Obvs.AzureServiceBus/Properties/AssemblyInfo.cs
+++ b/Obvs.AzureServiceBus/Properties/AssemblyInfo.cs
@@ -14,8 +14,8 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-[assembly: AssemblyVersion("0.15.0.*")]
-[assembly: AssemblyInformationalVersion("0.15.0-beta2")]
+[assembly: AssemblyVersion("0.15.1.*")]
+[assembly: AssemblyInformationalVersion("0.15.1-beta2")]
 
 [assembly: InternalsVisibleTo("Obvs.AzureServiceBus.Tests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]


### PR DESCRIPTION
The root of the problem was that DefaultMessageBrokeredTable::GetBrokeredMessageForMessage was only returning already registered BrokeredMessage instances and, if there wasn't one, it would just return null because it was only using TryGetValue. Now using GetOrCreate instead so that the first request to get a BrokeredMessage will create it.
