### PR TITLE
Fixing Outgoing Message Properties not being applied

### DIFF
--- a/Obvs.AzureServiceBus.Tests/EndpointProviderFacts.cs
+++ b/Obvs.AzureServiceBus.Tests/EndpointProviderFacts.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -24,6 +23,8 @@ namespace Obvs.AzureServiceBus.Tests
 
         private readonly List<MessageTypeMessagingEntityMappingDetails> _messageTypePathMappings;
 
+        private readonly Mock<IMessageOutgoingPropertiesTable> _mockMessageOutgoingPropertiesTable;
+
 
         public EndpointProviderFacts()
         {
@@ -32,6 +33,8 @@ namespace Obvs.AzureServiceBus.Tests
                 new MessageTypeMessagingEntityMappingDetails(typeof(TestCommand), "commands", MessagingEntityType.Queue),
                 new MessageTypeMessagingEntityMappingDetails(typeof(TestEvent), "events", MessagingEntityType.Topic)
             };
+
+            _mockMessageOutgoingPropertiesTable = new Mock<IMessageOutgoingPropertiesTable>();
         }
 
         public class ConstructorFacts : EndpointProviderFacts
@@ -41,7 +44,7 @@ namespace Obvs.AzureServiceBus.Tests
             {
                 Action action = () =>
                 {
-                    new AzureServiceBusEndpointProvider<TestMessage, TestMessage, TestCommand, TestEvent, TestRequest, TestResponse>("TestEndpoint", null, Mock.Of<IMessageSerializer>(), Mock.Of<IMessageDeserializerFactory>(), _messageTypePathMappings, _testAssemblyFilter, _testMessageTypeFilter, new MessagePropertyProviderManager<TestMessage>());
+                    new AzureServiceBusEndpointProvider<TestMessage, TestMessage, TestCommand, TestEvent, TestRequest, TestResponse>("TestEndpoint", null, Mock.Of<IMessageSerializer>(), Mock.Of<IMessageDeserializerFactory>(), _messageTypePathMappings, _testAssemblyFilter, _testMessageTypeFilter, new MessagePropertyProviderManager<TestMessage>(), _mockMessageOutgoingPropertiesTable.Object);
                 };
 
                 action.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("messagingFactory");
@@ -52,7 +55,7 @@ namespace Obvs.AzureServiceBus.Tests
             {
                 Action action = () =>
                 {
-                    new AzureServiceBusEndpointProvider<TestMessage, TestMessage, TestCommand, TestEvent, TestRequest, TestResponse>("TestEndpoint", Mock.Of<IMessagingFactory>(), null, Mock.Of<IMessageDeserializerFactory>(), _messageTypePathMappings, _testAssemblyFilter, _testMessageTypeFilter, new MessagePropertyProviderManager<TestMessage>());
+                    new AzureServiceBusEndpointProvider<TestMessage, TestMessage, TestCommand, TestEvent, TestRequest, TestResponse>("TestEndpoint", Mock.Of<IMessagingFactory>(), null, Mock.Of<IMessageDeserializerFactory>(), _messageTypePathMappings, _testAssemblyFilter, _testMessageTypeFilter, new MessagePropertyProviderManager<TestMessage>(), _mockMessageOutgoingPropertiesTable.Object);
                 };
 
                 action.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("messageSerializer");
@@ -63,7 +66,7 @@ namespace Obvs.AzureServiceBus.Tests
             {
                 Action action = () =>
                 {
-                    new AzureServiceBusEndpointProvider<TestMessage, TestMessage, TestCommand, TestEvent, TestRequest, TestResponse>("TestEndpoint", Mock.Of<IMessagingFactory>(), Mock.Of<IMessageSerializer>(), null, _messageTypePathMappings, _testAssemblyFilter, _testMessageTypeFilter, new MessagePropertyProviderManager<TestMessage>());
+                    new AzureServiceBusEndpointProvider<TestMessage, TestMessage, TestCommand, TestEvent, TestRequest, TestResponse>("TestEndpoint", Mock.Of<IMessagingFactory>(), Mock.Of<IMessageSerializer>(), null, _messageTypePathMappings, _testAssemblyFilter, _testMessageTypeFilter, new MessagePropertyProviderManager<TestMessage>(), _mockMessageOutgoingPropertiesTable.Object);
                 };
 
                 action.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("messageDeserializerFactory");
@@ -74,7 +77,7 @@ namespace Obvs.AzureServiceBus.Tests
             {
                 Action action = () =>
                 {
-                    new AzureServiceBusEndpointProvider<TestMessage, TestMessage, TestCommand, TestEvent, TestRequest, TestResponse>("TestEndpoint", Mock.Of<IMessagingFactory>(), Mock.Of<IMessageSerializer>(), Mock.Of<IMessageDeserializerFactory>(), null, _testAssemblyFilter, _testMessageTypeFilter, new MessagePropertyProviderManager<TestMessage>());
+                    new AzureServiceBusEndpointProvider<TestMessage, TestMessage, TestCommand, TestEvent, TestRequest, TestResponse>("TestEndpoint", Mock.Of<IMessagingFactory>(), Mock.Of<IMessageSerializer>(), Mock.Of<IMessageDeserializerFactory>(), null, _testAssemblyFilter, _testMessageTypeFilter, new MessagePropertyProviderManager<TestMessage>(), _mockMessageOutgoingPropertiesTable.Object);
                 };
 
                 action.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("messageTypePathMappings");
@@ -85,7 +88,7 @@ namespace Obvs.AzureServiceBus.Tests
             {
                 Action action = () =>
                 {
-                    new AzureServiceBusEndpointProvider<TestMessage, TestMessage, TestCommand, TestEvent, TestRequest, TestResponse>("TestEndpoint", Mock.Of<IMessagingFactory>(), Mock.Of<IMessageSerializer>(), Mock.Of<IMessageDeserializerFactory>(), new List<MessageTypeMessagingEntityMappingDetails>(), _testAssemblyFilter, _testMessageTypeFilter, new MessagePropertyProviderManager<TestMessage>());
+                    new AzureServiceBusEndpointProvider<TestMessage, TestMessage, TestCommand, TestEvent, TestRequest, TestResponse>("TestEndpoint", Mock.Of<IMessagingFactory>(), Mock.Of<IMessageSerializer>(), Mock.Of<IMessageDeserializerFactory>(), new List<MessageTypeMessagingEntityMappingDetails>(), _testAssemblyFilter, _testMessageTypeFilter, new MessagePropertyProviderManager<TestMessage>(), _mockMessageOutgoingPropertiesTable.Object);
                 };
 
                 action.ShouldThrow<ArgumentException>().And.ParamName.Should().Be("messageTypePathMappings");
@@ -96,7 +99,17 @@ namespace Obvs.AzureServiceBus.Tests
             {
                 Action action = () =>
                 {
-                    new AzureServiceBusEndpointProvider<TestMessage, TestMessage, TestCommand, TestEvent, TestRequest, TestResponse>("TestEndpoint", Mock.Of<IMessagingFactory>(), Mock.Of<IMessageSerializer>(), Mock.Of<IMessageDeserializerFactory>(), _messageTypePathMappings, _testAssemblyFilter, _testMessageTypeFilter, null);
+                    new AzureServiceBusEndpointProvider<TestMessage, TestMessage, TestCommand, TestEvent, TestRequest, TestResponse>("TestEndpoint", Mock.Of<IMessagingFactory>(), Mock.Of<IMessageSerializer>(), Mock.Of<IMessageDeserializerFactory>(), _messageTypePathMappings, _testAssemblyFilter, _testMessageTypeFilter, null, _mockMessageOutgoingPropertiesTable.Object);
+                };
+
+                action.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("messagePropertyProviderManager");
+            }
+
+            public void CreatingWithNullMessageOutgoingMessagePropertiesTableThrows()
+            {
+                Action action = () =>
+                {
+                    new AzureServiceBusEndpointProvider<TestMessage, TestMessage, TestCommand, TestEvent, TestRequest, TestResponse>("TestEndpoint", Mock.Of<IMessagingFactory>(), Mock.Of<IMessageSerializer>(), Mock.Of<IMessageDeserializerFactory>(), _messageTypePathMappings, _testAssemblyFilter, _testMessageTypeFilter, new MessagePropertyProviderManager<TestMessage>(), null);
                 };
 
                 action.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("messagePropertyProviderManager");
@@ -118,7 +131,7 @@ namespace Obvs.AzureServiceBus.Tests
             public void CreateEndpoint()
             {
                 new AzureServiceBusEndpointProvider<TestMessage, TestMessage, TestCommand, TestEvent, TestRequest, TestResponse>(
-                    "TestEndpoint", _mockMessagingFactory.Object, _mockMessageSerializer.Object, _mockMessageDeserializerFactory.Object, _messageTypePathMappings, _testAssemblyFilter, _testMessageTypeFilter, _messagePropertyProviderManager)
+                    "TestEndpoint", _mockMessagingFactory.Object, _mockMessageSerializer.Object, _mockMessageDeserializerFactory.Object, _messageTypePathMappings, _testAssemblyFilter, _testMessageTypeFilter, _messagePropertyProviderManager, _mockMessageOutgoingPropertiesTable.Object)
                     .CreateEndpoint();
             }
 
@@ -135,7 +148,7 @@ namespace Obvs.AzureServiceBus.Tests
                     .Returns(mockMessageSender.Object);
 
                 var endpointProvider = new AzureServiceBusEndpointProvider<TestMessage, TestMessage, TestCommand, TestEvent, TestRequest, TestResponse>(
-                    "TestEndpoint", _mockMessagingFactory.Object, new JsonMessageSerializer(), new JsonMessageDeserializerFactory(), _messageTypePathMappings, _testAssemblyFilter, _testMessageTypeFilter, _messagePropertyProviderManager);
+                    "TestEndpoint", _mockMessagingFactory.Object, new JsonMessageSerializer(), new JsonMessageDeserializerFactory(), _messageTypePathMappings, _testAssemblyFilter, _testMessageTypeFilter, _messagePropertyProviderManager, _mockMessageOutgoingPropertiesTable.Object);
 
                 var testEvent = new TestSpecificEvent1
                 {
@@ -166,7 +179,7 @@ namespace Obvs.AzureServiceBus.Tests
             public void CreateEndpointClient()
             {
                 new AzureServiceBusEndpointProvider<TestMessage, TestMessage, TestCommand, TestEvent, TestRequest, TestResponse>(
-                    "TestEndpoint", _mockMessagingFactory.Object, _mockMessageSerializer.Object, _mockMessageDeserializerFactory.Object, _messageTypePathMappings, _testAssemblyFilter, _testMessageTypeFilter, _messagePropertyProviderManager)
+                    "TestEndpoint", _mockMessagingFactory.Object, _mockMessageSerializer.Object, _mockMessageDeserializerFactory.Object, _messageTypePathMappings, _testAssemblyFilter, _testMessageTypeFilter, _messagePropertyProviderManager, _mockMessageOutgoingPropertiesTable.Object)
                     .CreateEndpointClient();
             }
 
@@ -188,19 +201,19 @@ namespace Obvs.AzureServiceBus.Tests
 
                 var mockMessageSender = new Mock<IMessageSender>();
                 mockMessageSender.Setup(mr => mr.SendAsync(It.IsNotNull<BrokeredMessage>()))
-                    .Callback<BrokeredMessage>(bm => 
+                    .Callback<BrokeredMessage>(bm =>
                     {
 
                         publishedEventBrokeredMessageTaskCompletionSource.SetResult(bm);
                         publishedEventBrokeredMessageTaskCompletionSource = new TaskCompletionSource<BrokeredMessage>();
                     })
-                    .Returns(Task.FromResult(true));                
+                    .Returns(Task.FromResult(true));
 
                 _mockMessagingFactory.Setup(mf => mf.CreateMessageSender(It.IsNotNull<Type>(), It.IsNotNull<string>()))
                     .Returns(mockMessageSender.Object);
 
                 var endpointProvider = new AzureServiceBusEndpointProvider<TestMessage, TestMessage, TestCommand, TestEvent, TestRequest, TestResponse>(
-                    "TestEndpoint", _mockMessagingFactory.Object, new JsonMessageSerializer(), new JsonMessageDeserializerFactory(), _messageTypePathMappings, _testAssemblyFilter, _testMessageTypeFilter, _messagePropertyProviderManager);
+                    "TestEndpoint", _mockMessagingFactory.Object, new JsonMessageSerializer(), new JsonMessageDeserializerFactory(), _messageTypePathMappings, _testAssemblyFilter, _testMessageTypeFilter, _messagePropertyProviderManager, _mockMessageOutgoingPropertiesTable.Object);
 
                 var endpointClient = endpointProvider.CreateEndpointClient();
 
@@ -221,8 +234,8 @@ namespace Obvs.AzureServiceBus.Tests
 
                 _mockMessagingFactory.Verify(mf => mf.CreateMessageReceiver(It.Is<Type>(it => it == typeof(TestSpecificEvent1)), testSubscriptionPath, It.Is<MessageReceiveMode>(mrm => mrm == MessageReceiveMode.ReceiveAndDelete)), Times.Once());
 
-                /* NOTE: it's possible ReceiveAsync will be called up to two times due to concurrency here: 
-                 * the first time will return the msg for the test, but then it's possible there will be a second call to ReceiveAsync to wait for the next message 
+                /* NOTE: it's possible ReceiveAsync will be called up to two times due to concurrency here:
+                 * the first time will return the msg for the test, but then it's possible there will be a second call to ReceiveAsync to wait for the next message
                  * before the subscription is shut down.
                  */
                 mockMessageReceiver.Verify(mr => mr.ReceiveAsync(), Times.AtMost(2));

--- a/Obvs.AzureServiceBus/Configuration/AzureServiceBusFluentConfig.cs
+++ b/Obvs.AzureServiceBus/Configuration/AzureServiceBusFluentConfig.cs
@@ -106,6 +106,7 @@ namespace Obvs.AzureServiceBus.Configuration
         private INamespaceManager _namespaceManager;
         private MessagePropertyProviderManager<TMessage> _messagePropertyProviderManager = new MessagePropertyProviderManager<TMessage>();
         private IMessagingEntityVerifier _messagingEntityVerifier;
+        private IMessageOutgoingPropertiesTable _messageOutgoingPropertiesTable = MessageOutgoingPropertiesTable.ConfiguredInstance;
 
         public AzureServiceBusFluentConfig(ICanAddEndpoint<TMessage, TCommand, TEvent, TRequest, TResponse> canAddEndpoint)
         {
@@ -148,7 +149,7 @@ namespace Obvs.AzureServiceBus.Configuration
 
             _messagingEntityVerifier.EnsureMessagingEntitiesExist(_messageTypePathMappings);
 
-            return new AzureServiceBusEndpointProvider<TServiceMessage, TMessage, TCommand, TEvent, TRequest, TResponse>(_serviceName, _messagingFactory, _serializer, _deserializerFactory, _messageTypePathMappings, _assemblyFilter, _typeFilter, _messagePropertyProviderManager);
+            return new AzureServiceBusEndpointProvider<TServiceMessage, TMessage, TCommand, TEvent, TRequest, TResponse>(_serviceName, _messagingFactory, _serializer, _deserializerFactory, _messageTypePathMappings, _assemblyFilter, _typeFilter, _messagePropertyProviderManager, _messageOutgoingPropertiesTable);
         }
 
         public ICanSpecifyAzureServiceBusMessagingFactory<TMessage, TCommand, TEvent, TRequest, TResponse> WithConnectionString(string connectionString)

--- a/Obvs.AzureServiceBus/Infrastructure/IMessageBrokeredMessageTable.cs
+++ b/Obvs.AzureServiceBus/Infrastructure/IMessageBrokeredMessageTable.cs
@@ -38,7 +38,14 @@ namespace Obvs.AzureServiceBus.Infrastructure
             _innerTable.Add(message, brokeredMessage);
         }
 
-        public BrokeredMessage GetBrokeredMessageForMessage(object message) => _innerTable.GetOrCreateValue(message);
+        public BrokeredMessage GetBrokeredMessageForMessage(object message)
+        {
+            BrokeredMessage result;
+
+            _innerTable.TryGetValue(message, out result);
+
+            return result;
+        }
 
         public void RemoveBrokeredMessageForMessage(object message) => _innerTable.Remove(message);
     }

--- a/Obvs.AzureServiceBus/Infrastructure/IMessageOutgoingPropertiesTable.cs
+++ b/Obvs.AzureServiceBus/Infrastructure/IMessageOutgoingPropertiesTable.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+
+namespace Obvs.AzureServiceBus.Infrastructure
+{
+    public interface IMessageOutgoingPropertiesTable
+    {
+        void SetOutgoingPropertiesForMessage(object message, IOutgoingMessageProperties outgoingMessageProperties);
+
+        IOutgoingMessageProperties GetOutgoingPropertiesForMessage(object message);
+
+        void RemoveOutgoingPropertiesForMessage(object message);
+    }
+
+    internal sealed class MessageOutgoingPropertiesTable
+    {
+        private static readonly IMessageOutgoingPropertiesTable Instance = new DefaultMessageOutgoingPropertiesTable();
+
+        public static IMessageOutgoingPropertiesTable ConfiguredInstance
+        {
+            get
+            {
+                return Instance;
+            }
+        }
+    }
+
+    internal sealed class DefaultMessageOutgoingPropertiesTable : IMessageOutgoingPropertiesTable
+    {
+        ConditionalWeakTable<object, IOutgoingMessageProperties> _innerTable = new ConditionalWeakTable<object, IOutgoingMessageProperties>();
+
+        public void SetOutgoingPropertiesForMessage(object message, IOutgoingMessageProperties outgoingMessageProperties)
+        {
+            if(message == null) throw new ArgumentNullException(nameof(message));
+            if(outgoingMessageProperties == null) throw new ArgumentNullException(nameof(outgoingMessageProperties));
+
+            _innerTable.Add(message, outgoingMessageProperties);
+        }
+
+        public IOutgoingMessageProperties GetOutgoingPropertiesForMessage(object message)
+        {
+            IOutgoingMessageProperties result;
+
+            _innerTable.TryGetValue(message, out result);
+
+            return result;
+        }
+
+        public void RemoveOutgoingPropertiesForMessage(object message) => _innerTable.Remove(message);
+    }
+}

--- a/Obvs.AzureServiceBus/Obvs.AzureServiceBus.csproj
+++ b/Obvs.AzureServiceBus/Obvs.AzureServiceBus.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Configuration\AzureServiceBusFluentConfig.cs" />
     <Compile Include="Configuration\ConfigurationUtilities.cs" />
     <Compile Include="Configuration\MessageTypeMessagingEntityMappingDetails.cs" />
+    <Compile Include="Infrastructure\IMessageOutgoingPropertiesTable.cs" />
     <Compile Include="Infrastructure\IMessageBrokeredMessageTable.cs" />
     <Compile Include="Infrastructure\IMessagingEntityFactory.cs" />
     <Compile Include="Infrastructure\IMessagingEntityVerifier.cs" />

--- a/Obvs.AzureServiceBus/Obvs.AzureServiceBus.nuspec
+++ b/Obvs.AzureServiceBus/Obvs.AzureServiceBus.nuspec
@@ -11,7 +11,7 @@
         <copyright>Copyright 2015</copyright>
         <tags>Azure Commands Events CQRS Rx Observable</tags>
         <releaseNotes>
-            FIX: fixing bug where getting outgoing message properties for a newly created message would result in a NullReferenceException.
+            FIX: fixing bug outgoing message properties were not actually being applied to the outgoing BrokeredMessage.
         </releaseNotes>
     </metadata>
 </package>

--- a/Obvs.AzureServiceBus/Properties/AssemblyInfo.cs
+++ b/Obvs.AzureServiceBus/Properties/AssemblyInfo.cs
@@ -14,8 +14,8 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-[assembly: AssemblyVersion("0.15.1.*")]
-[assembly: AssemblyInformationalVersion("0.15.1-beta2")]
+[assembly: AssemblyVersion("0.15.2.*")]
+[assembly: AssemblyInformationalVersion("0.15.2-beta2")]
 
 [assembly: InternalsVisibleTo("Obvs.AzureServiceBus.Tests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]


### PR DESCRIPTION
Fixing bug where outgoing message properties were not applied.

This was happening because, after all that work, the MessagePublisher was not actually using the BrokeredMessage that was created in the MessageBrokeredMessage table because it has to create the BrokeredMessage itself because the only way it can set the body of the BrokeredMessage is by passing it to the constructor.

The change was to keep a completely separate table, again based on CWT, of IOutgoingMessageProperties instances "on the side" that MessagePublisher will now look for and apply to the BrokeredMessage before sending off.
